### PR TITLE
Addressing Yang doctors review

### DIFF
--- a/src/yang/ietf-bgp-policy.yang
+++ b/src/yang/ietf-bgp-policy.yang
@@ -296,7 +296,7 @@ module ietf-bgp-policy {
 	    "Value for the number of communities in the route update.";
 	}
 
-	choice opertion {
+	choice operation {
 	  case eq {
 	    leaf eq {
 	      type empty;
@@ -341,7 +341,7 @@ module ietf-bgp-policy {
 	    "Value of the AS path length in the route update.";
 	}
 
-	choice opertion {
+	choice operation {
 	  case eq {
 	    leaf eq {
 	      type empty;

--- a/src/yang/ietf-bgp-policy.yang
+++ b/src/yang/ietf-bgp-policy.yang
@@ -224,62 +224,37 @@ module ietf-bgp-policy {
     }
   }
 
-  grouping set-community-action-common {
-    description
-      "Common leaves for set-community and set-ext-community
-       actions";
-    leaf method {
-      type enumeration {
-        enum inline {
-          description
-            "The extended communities are specified inline as a
-             list";
-        }
-        enum reference {
-          description
-            "The extended communities are specified by referencing a
-             defined ext-community set";
-        }
-      }
-      description
-        "Indicates the method used to specify the extended
-         communities for the set-ext-community action";
-    }
-    leaf options {
-      type bgp-set-community-option-type;
-      description
-        "Options for modifying the community attribute with
-         the specified values.  These options apply to both
-         methods of setting the community attribute.";
-    }
-  }
-
   augment "/rpol:routing-policy/rpol:policy-definitions/" +
           "rpol:policy-definition/rpol:policy-statements/" +
           "rpol:statement/rpol:conditions" {
     description
       "BGP policy conditions added to routing policy module.";
+
     container bgp-conditions {
       description
         "Top-level container for BGP specific policy conditions.";
+
       leaf med-eq {
         type uint32;
         description
           "Condition to check if the received MED value is equal to
            the specified value.";
       }
+
       leaf origin-eq {
         type bt:bgp-origin-attr-type;
         description
           "Condition to check if the route origin is equal to the
            specified value.";
       }
+
       leaf-list next-hop-in {
         type inet:ip-address-no-zone;
         description
           "List of next hop addresses to check for in the route
            update.";
       }
+
       leaf-list afi-safi-in {
         type identityref {
           base bt:afi-safi-type;
@@ -287,12 +262,14 @@ module ietf-bgp-policy {
         description
           "List of address families which the NLRI may be within.";
       }
+
       leaf local-pref-eq {
         type uint32;
         description
           "Condition to check if the local pref attribute is equal to
-           the specified value";
+           the specified value.";
       }
+
       leaf route-type {
         type enumeration {
           enum internal {
@@ -307,11 +284,47 @@ module ietf-bgp-policy {
         description
           "Condition to check the route type in the route update";
       }
+
       container community-count {
         description
           "Value and comparison operations for conditions based on the
-           number of communities in the route update";
+           number of communities in the route update.";
+
+	leaf community-count {
+	  type uint32;
+	  description
+	    "Value for the number of communities in the route update.";
+	}
+
+	choice opertion {
+	  case eq {
+	    leaf eq {
+	      type empty;
+	      description
+		"Check to see if the value is equal.";
+	    }
+	  }
+
+	  case lt-or-eq {
+	    leaf lt-or-eq {
+	      type empty;
+	      description
+		"Check to see if the value is less than or equal.";
+	    }
+	  }
+
+	  case gt-or-eq {
+	    leaf gt-or-eq {
+	      type empty;
+	      description
+		"Check to see if the value is greater than or equal.";
+	    }
+	  }
+	  description
+	    "Choice of operations on the value of community-count.";
+	}
       }
+
       container as-path-length {
         description
           "Value and comparison operations for conditions based on the
@@ -321,12 +334,47 @@ module ietf-bgp-policy {
            RFC 4271 rules.";
         reference
           "RFC 4271: BGP-4.";
+
+	leaf as-path-length {
+	  type uint32;
+	  description
+	    "Value of the AS path length in the route update.";
+	}
+
+	choice opertion {
+	  case eq {
+	    leaf eq {
+	      type empty;
+	      description
+		"Check to see if the value is equal.";
+	    }
+	  }
+
+	  case lt-or-eq {
+	    leaf lt-or-eq {
+	      type empty;
+	      description
+		"Check to see if the value is less than or equal.";
+	    }
+	  }
+
+	  case gt-or-eq {
+	    leaf gt-or-eq {
+	      type empty;
+	      description
+		"Check to see if the value is greater than or equal.";
+	    }
+	  }
+	  description
+	    "Choice of operations on the value of as-path-len.";
+	}
       }
+
       container match-community-set {
         description
           "Top-level container for match conditions on communities.
            Match a referenced community-set according to the logic
-           defined in the match-set-options leaf";
+           defined in the match-set-options leaf.";
         leaf community-set {
           type leafref {
             path "/rpol:routing-policy/rpol:defined-sets/"
@@ -334,14 +382,15 @@ module ietf-bgp-policy {
                + "bp:community-set/bp:name";
           }
           description
-            "References a defined community set";
+            "References a defined community set.";
         }
         uses rpol:match-set-options-group;
       }
+
       container match-ext-community-set {
         description
           "Match a referenced extended community-set according to the
-           logic defined in the match-set-options leaf";
+           logic defined in the match-set-options leaf.";
         leaf ext-community-set {
           type leafref {
             path "/rpol:routing-policy/rpol:defined-sets/"
@@ -349,14 +398,14 @@ module ietf-bgp-policy {
                + "bp:ext-community-set/bp:name";
           }
           description
-            "References a defined extended community set";
+            "References a defined extended community set.";
         }
         uses rpol:match-set-options-group;
       }
       container match-as-path-set {
         description
           "Match a referenced as-path set according to the logic
-           defined in the match-set-options leaf";
+           defined in the match-set-options leaf.";
         leaf as-path-set {
           type leafref {
             path "/rpol:routing-policy/rpol:defined-sets/"
@@ -387,17 +436,17 @@ module ietf-bgp-policy {
       leaf set-local-pref {
         type uint32;
         description
-          "Set the local pref attribute on the route update";
+          "Set the local pref attribute on the route.";
       }
       leaf set-next-hop {
         type bgp-next-hop-type;
         description
-          "Set the next-hop attribute in the route update";
+          "Set the next-hop attribute in the route.";
       }
       leaf set-med {
         type bgp-set-med-type;
         description
-          "Set the med metric attribute in the route update";
+          "Set the med metric attribute in the route.";
       }
       container set-as-path-prepend {
         description
@@ -413,50 +462,52 @@ module ietf-bgp-policy {
              supported by the implementation.";
         }
       }
+
       container set-community {
         description
           "Action to set the community attributes of the route, along
            with options to modify how the community is modified.
            Communities may be set using an inline list OR
            reference to an existing defined set (not both).";
-        uses set-community-action-common;
-        container inline {
-          when "../method = 'inline'" {
-            description
-              "Active only when the set-community method is inline";
-          }
+
+        leaf options {
+          type bgp-set-community-option-type;
           description
-            "Set the community values for the action inline with
-             a list.";
-          leaf-list communities {
-            type union {
-              type bt:bgp-std-community-type;
-              type bt:bgp-well-known-community-type;
-            }
-            description
-              "Set the community values for the update inline with a
-               list.";
-          }
+            "Options for modifying the community attribute with
+             the specified values.  These options apply to both
+             methods of setting the community attribute.";
         }
-        container reference {
-          when "../method = 'reference'" {
-            description
-              "Active only when the set-community method is reference";
-          }
+
+        choice method {
           description
-            "Provide a reference to a defined community set for the
-             set-community action";
-          leaf community-set-ref {
-            type leafref {
-              path "/rpol:routing-policy/rpol:defined-sets/"
-                 + "bp:bgp-defined-sets/"
-                 + "bp:community-sets/bp:community-set/bp:name";
+            "Indicates the method used to specify the extended
+             communities for the set-community action";
+          case inline {
+            leaf-list communities {
+              type union {
+                type bt:bgp-std-community-type;
+                type bt:bgp-well-known-community-type;
+              }
+              description
+                "Set the community values for the update inline with a
+                 list.";
             }
-            description
-              "References a defined community set by name";
+          }
+
+          case reference {
+            leaf community-set-ref {
+              type leafref {
+                path "/rpol:routing-policy/rpol:defined-sets/"
+                   + "bp:bgp-defined-sets/"
+                   + "bp:community-sets/bp:community-set/bp:name";
+              }
+              description
+                "References a defined community set by name";
+            }
           }
         }
       }
+
       container set-ext-community {
         description
           "Action to set the extended community attributes of the
@@ -464,41 +515,40 @@ module ietf-bgp-policy {
            modified. Extended communities may be set using an inline
            list OR a reference to an existing defined set (but not
            both).";
-        uses set-community-action-common;
-        container inline {
-          when "../method = 'inline'" {
-            description
-              "Active only when the set-community method is inline";
-          }
+
+        leaf options {
+          type bgp-set-community-option-type;
           description
-            "Set the extended community values for the action inline
-             with a list.";
-          leaf-list communities {
-            type union {
-              type rt-types:route-target;
-              type bt:bgp-well-known-community-type;
-            }
-            description
-              "Set the extended community values for the update inline
-               with a list.";
-          }
+            "Options for modifying the community attribute with
+             the specified values.  These options apply to both
+             methods of setting the community attribute.";
         }
-        container reference {
-          when "../method = 'reference'" {
-            description
-              "Active only when the set-community method is reference";
-          }
+
+        choice method {
           description
-            "Provide a reference to an extended community set for the
-             set-ext-community action";
-          leaf ext-community-set-ref {
-            type leafref {
-              path "/rpol:routing-policy/rpol:defined-sets/"
-                 + "bp:bgp-defined-sets/bp:ext-community-sets/"
-                 + "bp:ext-community-set/bp:name";
+            "Indicates the method used to specify the extended
+             communities for the set-ext-community action";
+          case  inline {
+            leaf-list communities {
+              type union {
+                type rt-types:route-target;
+                type bt:bgp-well-known-community-type;
+              }
+              description
+                "Set the extended community values for the update inline
+                 with a list.";
             }
-            description
-              "References a defined extended community set by name";
+          }
+          case reference {
+            leaf ext-community-set-ref {
+              type leafref {
+                path "/rpol:routing-policy/rpol:defined-sets/"
+                   + "bp:bgp-defined-sets/bp:ext-community-sets/"
+                   + "bp:ext-community-set/bp:name";
+              }
+              description
+                "References a defined extended community set by name";
+            }
           }
         }
       }


### PR DESCRIPTION
This PR addresses two main YANG doctor's review comments

- It addresses the question of using case statement to model set-community and set-ext-community actions. Please check that I have not changed the logic in any material way.
- Adds a leaf and a set of actions one can perform for community-count and as-path-length.