### PR TITLE
Jhaas/issue 73

### DIFF
--- a/src/yang/ietf-bgp-common.yang
+++ b/src/yang/ietf-bgp-common.yang
@@ -142,7 +142,6 @@ submodule ietf-bgp-common {
         range "0..max";
       }
       units "seconds";
-      default "15";
       description
         "Time interval (in seconds) for the MinASOriginationInterval
          timer. The suggested value for this timer is 15 seconds.";


### PR DESCRIPTION
Issue 73: BGP MRAI/MAOI timers shouldn't have default values. Let the implementation choose.

Closes #73