### PR TITLE
How to "build" BGP draft using a container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,19 @@
-FROM fredrikjanssonse/etsi-sol006-base-image:6.6
-# FROM mjethanandani/compile-yang:latest
+FROM mjethanandani/build-yang:1.0
 
-RUN perl -0777 -i -pe 's|<operational>\n      <enabled>false</enabled>|<operational><enabled>true</enabled>|g' /opt/confd/etc/confd/confd.conf
+# Everything below is draft specific
 
-# RUN apt-get update; apt-get install -y python-pip libxml2 libxml2-utils; rm -rf /tmp/*
-# RUN pip install paramiko
+RUN mkdir -p /git/ietf-bgp-model/draft/ /git/ietf-bgp-model/src/ /git/ietf-bgp-model/src/yang /git/ietf-bgp-model/bin/
 
-ADD bin/*.yang src/
-ADD bin/submodules/*.yang src/
-ADD src/yang/example-bgp-configuration-*.xml src/
-ADD bin/yang-parameters/*.yang src/
-ADD confdc-run-test.sh /
+ADD .git/ /git/ietf-bgp-model/
+ADD src/validate-and-gen-trees.sh /git/ietf-bgp-model/src
+ADD src/addstyle.sed /git/ietf-bgp-model/src
+ADD src/download-dependent-models.py /git/ietf-bgp-model/src
+ADD src/insert-figures.sh /git/ietf-bgp-model/src
+ADD src/replace.sh /git/ietf-bgp-model/src/replace.sh
+ADD src/yang/ /git/ietf-bgp-model/src/yang/
+ADD src/yang/example* /git/ietf-bgp-model/src/yang/
+ADD draft/Makefile /git/ietf-bgp-model/draft/
+ADD draft/draft-ietf-idr-bgp-model.xml /git/ietf-bgp-model/draft/
+ADD start.sh /
 
-CMD ["/confdc-run-test.sh"]
+CMD ["./start.sh"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,43 @@
-# ietf-bgp-yang
+There are several ways to "build" this draft, once the repository has
+been cloned.
+
+Native Build
+
+To build the draft on the machine where the repository exits, one has to
+have all the tools neccesary. These include building other tools (from
+source) used by this model, i.e. yanglint and yanger. Details on how
+to buld them can be found in the link to the tools.
+
+Other than those tools one will need
+
+- python3 and python3-pip
+- curl
+- rsync
+- idnits
+- awk (or gawk installed as awk)
+- gsed (or sed installed as gsed)
+
+In addition pip should be used to install
+
+- pyang
+- xml2rfc
+- xym
+
+Once all the tools are installed the following commands will build the draft
+
+% cd draft
+% make clean; make
+
+Build using Docker
+
+In one does not want to be bothered with all the tools necessary to build
+the draft, one can use Docker. Make sure it is installed and then in the
+root of the repository type
+
+% make container
+
+If the draft is build, it can be copied out of the container using the
+command:
+
+docker cp :/file/path/within/container /host/path/target
+

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Native Build
 To build the draft on the machine where the repository exits, one has to
 have all the tools neccesary. These include building other tools (from
 source) used by this model, i.e. yanglint and yanger. Details on how
-to buld them can be found in the link to the tools.
+to build them can be found in the link to the tools.
 
 Other than those tools one will need
 

--- a/src/download-dependent-models.py
+++ b/src/download-dependent-models.py
@@ -8,6 +8,7 @@ list_of_ietf_models =\
   ["ietf-if-vlan-encapsulation", "draft-ietf-netmod-sub-intf-vlan-model", "07"],
   ["ietf-if-flexible-encapsulation", "draft-ietf-netmod-sub-intf-vlan-model", "07"],
   ["iana-bfd-types", "draft-ietf-bfd-yang", "17"],
+  ["ietf-crypto-types", "draft-ietf-netconf-crypto-types", "20"],
   ["ietf-tcp-client", "draft-ietf-netconf-tcp-client-server", "10"],
   ["ietf-tcp-server", "draft-ietf-netconf-tcp-client-server", "10"],
   ["ietf-tcp-common", "draft-ietf-netconf-tcp-client-server", "10"] ]

--- a/src/validate-and-gen-trees.sh
+++ b/src/validate-and-gen-trees.sh
@@ -4,7 +4,7 @@
 # Does the user have all the IETF published models.
 #
 if [ ! -d ../../iana/yang-parameters ]; then
-   rsync -avz --delete rsync.ietf.org::iana/yang-parameters ../../
+   rsync -avz --delete rsync.iana.org::assignments/yang-parameters ../../
 fi
 
 for i in ../bin/ietf-*\@$(date +%Y-%m-%d).yang
@@ -12,9 +12,9 @@ do
     name=$(echo $i | cut -f 1-3 -d '.')
     echo "Validating $name.yang"
     if test "${name#^example}" = "$name"; then
-        response=`pyang --ietf --lint --strict --canonical -p ../../iana/yang-parameters -p ../bin/submodules -p ../bin -f tree --max-line-length=72 --tree-line-length=69 $name.yang > $name-tree.txt.tmp`
+        response=`pyang --ietf --lint --strict --canonical -p ../../yang-parameters -p ../bin/submodules -p ../bin -f tree --max-line-length=72 --tree-line-length=69 $name.yang > $name-tree.txt.tmp`
     else            
-        response=`pyang --ietf --strict --canonical -p ../../iana/yang-parameters -p ../bin/submodules -p ../bin -f tree --max-line-length=72 --tree-line-length=69 $name.yang > $name-tree.txt.tmp`
+        response=`pyang --ietf --strict --canonical -p ../../yang-parameters -p ../bin/submodules -p ../bin -f tree --max-line-length=72 --tree-line-length=69 $name.yang > $name-tree.txt.tmp`
     fi
     if [ $? -ne 0 ]; then
         printf "$name.yang failed pyang validation\n"
@@ -24,7 +24,7 @@ do
         exit 1
     fi
     fold -w 71 $name-tree.txt.tmp > $name-tree.txt
-    response=`yanglint -p ../../iana/yang-parameters -p ../bin/submodules -p ../bin $name.yang -i`
+    response=`yanglint -p ../../yang-parameters -p ../bin/submodules -p ../bin $name.yang -i`
     if [ $? -ne 0 ]; then
         printf "$name.yang failed yanglint validation\n"
         printf "$response\n\n"
@@ -39,10 +39,10 @@ do
     name=$(echo $i | cut -f 1-3 -d '.')
     echo "Generating abridged tree diagram for $name.yang"
     if test "${name#^example}" = "$name"; then
-#       response=`pyang --lint --strict --canonical -p ../../iana/yang-parameters -p ../bin/submodules -p ../bin -f tree --tree-depth=3 --max-line-length=72 --tree-line-length=69 $name.yang > $name-sub-tree.txt.tmp`
-        response=`yanger --strict -p ../../iana/yang-parameters -p ../bin/submodules -p ../bin -p ../bin/dependent -f tree --tree-depth=3 $name.yang > $name-sub-tree.txt.tmp`
+#       response=`pyang --lint --strict --canonical -p ../../yang-parameters -p ../bin/submodules -p ../bin -f tree --tree-depth=3 --max-line-length=72 --tree-line-length=69 $name.yang > $name-sub-tree.txt.tmp`
+        response=`yanger --strict -p ../../yang-parameters -p ../bin/submodules -p ../bin -p ../bin/dependent -f tree --tree-depth=3 $name.yang > $name-sub-tree.txt.tmp`
     else            
-        response=`pyang --ietf --strict --canonical -p ../../iana/yang-parameters -p ../bin/submodules -p ../bin -f tree --tree-depth=3 --max-line-length=72 --tree-line-length=69 $name.yang > $name-sub-tree.txt.tmp`
+        response=`pyang --ietf --strict --canonical -p ../../yang-parameters -p ../bin/submodules -p ../bin -f tree --tree-depth=3 --max-line-length=72 --tree-line-length=69 $name.yang > $name-sub-tree.txt.tmp`
     fi
     if [ $? -ne 0 ]; then
         printf "$name.yang failed generation of sub-tree diagram\n"
@@ -61,9 +61,9 @@ do
     name=$(echo $i | cut -f 1-3 -d '.')
     echo "Validating $name.yang"
     if test "${name#^example}" = "$name"; then
-        response=`pyang --lint --strict --canonical -p ../../iana/yang-parameters -p ../bin/submodules -p ../bin -f tree --tree-depth=1 --max-line-length=72 --tree-line-length=69 $name.yang > $name-tree.txt.tmp`
+        response=`pyang --lint --strict --canonical -p ../../yang-parameters -p ../bin/submodules -p ../bin -f tree --tree-depth=1 --max-line-length=72 --tree-line-length=69 $name.yang > $name-tree.txt.tmp`
     else            
-        response=`pyang --ietf --strict --canonical -p ../../iana/yang-parameters -p ../bin/submodules -p ../bin -f tree --tree-depth=1 --max-line-length=72 --tree-line-length=69 $name.yang > $name-tree.txt.tmp`
+        response=`pyang --ietf --strict --canonical -p ../../yang-parameters -p ../bin/submodules -p ../bin -f tree --tree-depth=1 --max-line-length=72 --tree-line-length=69 $name.yang > $name-tree.txt.tmp`
     fi
     if [ $? -ne 0 ]; then
         printf "$name.yang failed generation of sub-tree diagram\n"
@@ -81,9 +81,9 @@ do
     name=$(echo $i | cut -f 1-3 -d '.')
     echo "Generating sub-tree diagram for rib from  $name.yang"
     if test "${name#^example}" = "$name"; then
-	response=`pyang --lint --strict --canonical -p ../../iana/yang-parameters -p ../bin/submodules -p ../bin -f tree --tree-path=rib/afi-safis --tree-depth=8 --max-line-length=72 --tree-line-length=69 $name.yang > $name-rib-tree.txt.tmp`
+	response=`pyang --lint --strict --canonical -p ../../yang-parameters -p ../bin/submodules -p ../bin -f tree --tree-path=rib/afi-safis --tree-depth=8 --max-line-length=72 --tree-line-length=69 $name.yang > $name-rib-tree.txt.tmp`
     else            
-        response=`pyang --ietf --strict --canonical -p ../../iana/yang-parameters -p ../bin/submodules -p ../bin -f tree --tree-path=rib/afi-safis --tree-depth=8 --max-line-length=72 --tree-line-length=69 $name.yang > $name-rib-tree.txt.tmp`
+        response=`pyang --ietf --strict --canonical -p ../../yang-parameters -p ../bin/submodules -p ../bin -f tree --tree-path=rib/afi-safis --tree-depth=8 --max-line-length=72 --tree-line-length=69 $name.yang > $name-rib-tree.txt.tmp`
     fi
     if [ $? -ne 0 ]; then
         printf "$name.yang failed generation of sub-tree diagram for rib\n"
@@ -102,7 +102,7 @@ for i in yang/example-bgp-configuration-*.xml
 do
     name=$(echo $i | cut -f 1-3 -d '.')
     echo "Validating $name.xml"
-    response=`yanglint -i -t config -p ../../iana/yang-parameters -p ../bin -p ../bin/submodules ../../iana/yang-parameters/ietf-network-instance@2019-01-21.yang ../bin/ietf-bgp\@$(date +%Y-%m-%d).yang $name.xml`
+    response=`yanglint -i -t config -p ../../yang-parameters -p ../bin -p ../bin/submodules ../../yang-parameters/ietf-network-instance@2019-01-21.yang ../bin/ietf-bgp\@$(date +%Y-%m-%d).yang $name.xml`
     if [ $? -ne 0 ]; then
        printf "failed (error code: $?)\n"
        printf "$response\n\n"

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+cd /git/ietf-bgp-model/draft
+make clean
+make


### PR DESCRIPTION
This commit introduces a method by which this draft can be "build" using a container. The only requirement from a tool perspective is that the machine where this repository has been cloned has Docker installed.

The rest of the process involves copying the files over to the container to "build" the draft. To copy the result of what is build, i.e. the draft, just type the following command.

docker cp <containerId>:/file/path/within/container /host/path/target