### PR TITLE
Clarify clear-route action

### DIFF
--- a/draft/Makefile
+++ b/draft/Makefile
@@ -63,7 +63,7 @@ $(next).xml: $(draft).xml ../src/yang/ietf-bgp-common-multiprotocol.yang ../src/
 	sed -e"s/YYYY-MM-DD/$(shell date +%Y-%m-%d)/" ../src/yang/example-newafi-bgp.yang > ../bin/example-newafi-bgp\@$(shell date +%Y-%m-%d).yang
 	sed -e"s/YYYY-MM-DD/$(shell date +%Y-%m-%d)/" ../src/yang/example-newco-bgp-a.2.yang > ../bin/example-newco-bgp-a.2\@$(shell date +%Y-%m-%d).yang
 
-	cd ../src; python ./download-dependent-models.py; ./validate-and-gen-trees.sh; cd ..;
+	cd ../src; ./validate-and-gen-trees.sh; cd ..;
 	../src/insert-figures.sh $@ > tmp; mv tmp $@
 
 rib: ../src/yang/ietf-bgp-rib.yang ../src/yang/ietf-bgp-rib-attributes.yang ../src/yang/ietf-bgp-rib-tables.yang ../src/yang/ietf-bgp-rib-types.yang

--- a/draft/draft-ietf-idr-bgp-model.xml
+++ b/draft/draft-ietf-idr-bgp-model.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="US-ASCII"?>
 <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
-<rfc category="std" docName="draft-ietf-idr-bgp-model-11" ipr="trust200902">
+<rfc category="std" docName="draft-ietf-idr-bgp-model-latest" ipr="trust200902">
   <?rfc toc="yes"?>
 
   <front>
@@ -98,7 +98,7 @@
       </address>
     </author>
 
-    <date day="10" month="July" year="2021"/>
+    <date/>
 
     <area>Routing</area>
 
@@ -149,7 +149,7 @@
         addresses policy configuration, by providing "hooks" for applying
         policies, and also defining BGP-specific policy features. The BGP
         policy features are intended to be used with the general routing
-        policy model defined in <xref target="I-D.ietf-rtgwg-policy-model">A
+        policy model defined in <xref target="RFC9067">A
         YANG Data Model for Routing Policy Management </xref>.</t>
 
         <t>The model conforms to the <xref target="RFC8342">NMDA</xref>
@@ -208,12 +208,8 @@
         document.</t>
 
         <t>RFC ZZZZ, where ZZZZ is the number assigned to <xref
-        target="I-D.ietf-rtgwg-policy-model">A YANG Data Model for Routing
+        target="RFC9067">A YANG Data Model for Routing
         Policy Management</xref>.</t>
-
-        <t>RFC BBBB, where BBBB is the number assigned to <xref
-        target="I-D.ietf-bfd-yang">YANG Data Model for Bidirectional Forward
-        Detection</xref>.</t>
       </section>
 
       <section title="Terminology">
@@ -281,7 +277,7 @@
           individual address-families for a neighbor within BGP.</t>
 
           <t>policy configuration -- hooks for application of the policies
-          defined in <xref target="I-D.ietf-rtgwg-policy-model">A YANG Data
+          defined in <xref target="RFC9067">A YANG Data
           Model for Routing Policy Management </xref> that act on routes sent
           (received) to (from) peers or other routing protocols and
           BGP-specific policy features.</t>
@@ -383,7 +379,7 @@ INSERT_TEXT_FROM_FILE(../bin/ietf-bgp@YYYY-MM-DD-sub-tree.txt)
       <section anchor="overview.policy" title="Policy configuration overview">
         <t>The BGP policy configuration model augments the generic YANG
         routing policy model described in <xref
-        target="I-D.ietf-rtgwg-policy-model">A YANG Data Model for Routing
+        target="RFC9067">A YANG Data Model for Routing
         Policy Management </xref>, which represents a condition-action policy
         framework for routing. This model adds BGP-specific conditions (e.g.,
         matching on the community attribute), and actions (e.g., setting local
@@ -634,7 +630,7 @@ reference: RFC XXXX
           including BGP policy</t>
 
           <t>ietf-bgp-policy - BGP-specific policy data definitions for use
-          with <xref target="I-D.ietf-rtgwg-policy-model"/> (described in more
+          with <xref target="RFC9067"/> (described in more
           detail <xref target="overview.policy"/>)</t>
         </list></t>
     </section>
@@ -661,7 +657,9 @@ reference: RFC XXXX
       and Procedures for Multicast in MPLS/BGP IP VPNs</xref>, <xref
       target="RFC6793">BGP Support for Four-Octet Autonomous System (AS)
       Number Space</xref>, <xref target="RFC7911">Advertisement of Multiple
-      Paths in BGP</xref>, <xref target="RFC8177">YANG Key Chain</xref>, and
+      Paths in BGP</xref>, <xref target="RFC8177">YANG Key Chain</xref>,
+      <xref target="RFC9127">YANG Data Model for Bidirectional Forwarding
+      Detection (BFD)</xref>, and
       <xref target="RFC8277">Carrying Label Information in BGP-4</xref>.</t>
 
       <section title="Main module and submodules for base items">
@@ -685,14 +683,14 @@ INSERT_TEXT_FROM_FILE(../bin/submodules/ietf-bgp-common@YYYY-MM-DD.yang)
 <CODE BEGINS> file "ietf-bgp-common-multiprotocol@YYYY-MM-DD.yang"
 INSERT_TEXT_FROM_FILE(../bin/submodules/ietf-bgp-common-multiprotocol@YYYY-MM-DD.yang)
 <CODE ENDS>
- 
+
         ]]></artwork>
           </figure><figure>
             <artwork><![CDATA[
 <CODE BEGINS> file "ietf-bgp-common-structure@YYYY-MM-DD.yang"
 INSERT_TEXT_FROM_FILE(../bin/submodules/ietf-bgp-common-structure@YYYY-MM-DD.yang)
 <CODE ENDS>
- 
+
         ]]></artwork>
           </figure><figure>
             <artwork><![CDATA[
@@ -706,7 +704,7 @@ INSERT_TEXT_FROM_FILE(../bin/submodules/ietf-bgp-peer-group@YYYY-MM-DD.yang)
 <CODE BEGINS> file "ietf-bgp-neighbor@YYYY-MM-DD.yang"
 INSERT_TEXT_FROM_FILE(../bin/submodules/ietf-bgp-neighbor@YYYY-MM-DD.yang)
 <CODE ENDS>
- 
+
 
 ]]></artwork>
           </figure></t>
@@ -718,7 +716,7 @@ INSERT_TEXT_FROM_FILE(../bin/submodules/ietf-bgp-neighbor@YYYY-MM-DD.yang)
 <CODE BEGINS> file "ietf-bgp-types@YYYY-MM-DD.yang"
 INSERT_TEXT_FROM_FILE(../bin/ietf-bgp-types@YYYY-MM-DD.yang)
 <CODE ENDS>
-       
+
         ]]></artwork>
           </figure></t>
       </section>
@@ -879,9 +877,9 @@ INSERT_TEXT_FROM_FILE(../bin/submodules/ietf-bgp-rib-tables@YYYY-MM-DD.yang)
 
       <?rfc include='reference.RFC.8349.xml?>
 
-      <?rfc include='reference.I-D.ietf-rtgwg-policy-model.xml'?>
+      <?rfc include='reference.RFC.9127.xml'?>
 
-      <?rfc include='reference.I-D.ietf-bfd-yang.xml'?>
+      <?rfc include='reference.RFC.9067.xml'?>
     </references>
 
     <section title="Examples">

--- a/draft/draft-ietf-idr-bgp-model.xml
+++ b/draft/draft-ietf-idr-bgp-model.xml
@@ -890,7 +890,11 @@ INSERT_TEXT_FROM_FILE(../bin/submodules/ietf-bgp-rib-tables@YYYY-MM-DD.yang)
 
       <section title="Creating BGP Instance">
         <t>This example shows how to enable BGP with the IPv4 unicast address
-        family, while adding one network to advertise.</t>
+        family, while adding one network to advertise. In addition, BFD
+	is configured at a neighbor level with a local multiplier of 2,
+	and within the choice of setting both transmit and receive
+	intervals, setting the 'desired-min-tx-interval' to 3.3 ms, and the
+	'required-min-rx-interval also to 3.3 ms.</t>
 
         <t><figure>
             <artwork><![CDATA[

--- a/draft/draft-ietf-idr-bgp-model.xml
+++ b/draft/draft-ietf-idr-bgp-model.xml
@@ -655,7 +655,8 @@ reference: RFC XXXX
       Number Space</xref>, <xref target="RFC7911">Advertisement of Multiple
       Paths in BGP</xref>, <xref target="RFC8177">YANG Key Chain</xref>,
       <xref target="RFC9127">YANG Data Model for Bidirectional Forwarding
-      Detection (BFD)</xref>, and
+      Detection (BFD)</xref>, <xref target="I-D.ietf-tcpm-yang-tcp">
+      YANG Model for Transmission Control Protocol</xref>, and
       <xref target="RFC8277">Carrying Label Information in BGP-4</xref>.</t>
 
       <section title="Main module and submodules for base items">
@@ -858,8 +859,6 @@ INSERT_TEXT_FROM_FILE(../bin/submodules/ietf-bgp-rib-tables@YYYY-MM-DD.yang)
       <?rfc include='reference.RFC.8528.xml'?>
 
       <?rfc include='reference.RFC.8529.xml'?>
-
-      <?rfc include='reference.I-D.ietf-bfd-yang.xml'?>
 
       <?rfc include='reference.I-D.ietf-tcpm-yang-tcp.xml'?>
     </references>

--- a/src/validate-and-gen-trees.sh
+++ b/src/validate-and-gen-trees.sh
@@ -3,8 +3,8 @@
 #
 # Does the user have all the IETF published models.
 #
-if [ ! -d ../../yang-parameters ]; then
-   rsync -avz --delete rsync.iana.org::assignments/yang-parameters ../../
+if [ ! -d ../../iana/yang-parameters ]; then
+   rsync -avz --delete rsync.iana.org::assignments/yang-parameters ../../iana/
 fi
 
 for i in ../bin/ietf-*\@$(date +%Y-%m-%d).yang
@@ -12,9 +12,9 @@ do
     name=$(echo $i | cut -f 1-3 -d '.')
     echo "Validating $name.yang"
     if test "${name#^example}" = "$name"; then
-        response=`pyang --ietf --lint --strict --canonical -p ../../yang-parameters -p ../bin/submodules -p ../bin -f tree --max-line-length=72 --tree-line-length=69 $name.yang > $name-tree.txt.tmp`
+        response=`pyang --ietf --lint --strict --canonical -p ../../iana/yang-parameters -p ../bin/submodules -p ../bin -f tree --max-line-length=72 --tree-line-length=69 $name.yang > $name-tree.txt.tmp`
     else            
-        response=`pyang --ietf --strict --canonical -p ../../yang-parameters -p ../bin/submodules -p ../bin -f tree --max-line-length=72 --tree-line-length=69 $name.yang > $name-tree.txt.tmp`
+        response=`pyang --ietf --strict --canonical -p ../../iana/yang-parameters -p ../bin/submodules -p ../bin -f tree --max-line-length=72 --tree-line-length=69 $name.yang > $name-tree.txt.tmp`
     fi
     if [ $? -ne 0 ]; then
         printf "$name.yang failed pyang validation\n"
@@ -24,7 +24,7 @@ do
         exit 1
     fi
     fold -w 71 $name-tree.txt.tmp > $name-tree.txt
-    response=`yanglint -p ../../yang-parameters -p ../bin/submodules -p ../bin $name.yang -i`
+    response=`yanglint -p ../../iana/yang-parameters -p ../bin/submodules -p ../bin $name.yang -i`
     if [ $? -ne 0 ]; then
         printf "$name.yang failed yanglint validation\n"
         printf "$response\n\n"
@@ -39,10 +39,10 @@ do
     name=$(echo $i | cut -f 1-3 -d '.')
     echo "Generating abridged tree diagram for $name.yang"
     if test "${name#^example}" = "$name"; then
-#       response=`pyang --lint --strict --canonical -p ../../yang-parameters -p ../bin/submodules -p ../bin -f tree --tree-depth=3 --max-line-length=72 --tree-line-length=69 $name.yang > $name-sub-tree.txt.tmp`
-        response=`yanger --strict -p ../../yang-parameters -p ../bin/submodules -p ../bin -p ../bin/dependent -f tree --tree-depth=3 $name.yang > $name-sub-tree.txt.tmp`
+#       response=`pyang --lint --strict --canonical -p ../../iana/yang-parameters -p ../bin/submodules -p ../bin -f tree --tree-depth=3 --max-line-length=72 --tree-line-length=69 $name.yang > $name-sub-tree.txt.tmp`
+        response=`yanger --strict -p ../../iana/yang-parameters -p ../bin/submodules -p ../bin -p ../../iana/yang-parameters -f tree --tree-depth=3 $name.yang > $name-sub-tree.txt.tmp`
     else            
-        response=`pyang --ietf --strict --canonical -p ../../yang-parameters -p ../bin/submodules -p ../bin -f tree --tree-depth=3 --max-line-length=72 --tree-line-length=69 $name.yang > $name-sub-tree.txt.tmp`
+        response=`pyang --ietf --strict --canonical -p ../../iana/yang-parameters -p ../bin/submodules -p ../bin -f tree --tree-depth=3 --max-line-length=72 --tree-line-length=69 $name.yang > $name-sub-tree.txt.tmp`
     fi
     if [ $? -ne 0 ]; then
         printf "$name.yang failed generation of sub-tree diagram\n"
@@ -61,9 +61,9 @@ do
     name=$(echo $i | cut -f 1-3 -d '.')
     echo "Validating $name.yang"
     if test "${name#^example}" = "$name"; then
-        response=`pyang --lint --strict --canonical -p ../../yang-parameters -p ../bin/submodules -p ../bin -f tree --tree-depth=1 --max-line-length=72 --tree-line-length=69 $name.yang > $name-tree.txt.tmp`
+        response=`pyang --lint --strict --canonical -p ../../iana/yang-parameters -p ../bin/submodules -p ../bin -f tree --tree-depth=1 --max-line-length=72 --tree-line-length=69 $name.yang > $name-tree.txt.tmp`
     else            
-        response=`pyang --ietf --strict --canonical -p ../../yang-parameters -p ../bin/submodules -p ../bin -f tree --tree-depth=1 --max-line-length=72 --tree-line-length=69 $name.yang > $name-tree.txt.tmp`
+        response=`pyang --ietf --strict --canonical -p ../../iana/yang-parameters -p ../bin/submodules -p ../bin -f tree --tree-depth=1 --max-line-length=72 --tree-line-length=69 $name.yang > $name-tree.txt.tmp`
     fi
     if [ $? -ne 0 ]; then
         printf "$name.yang failed generation of sub-tree diagram\n"
@@ -81,9 +81,9 @@ do
     name=$(echo $i | cut -f 1-3 -d '.')
     echo "Generating sub-tree diagram for rib from  $name.yang"
     if test "${name#^example}" = "$name"; then
-	response=`pyang --lint --strict --canonical -p ../../yang-parameters -p ../bin/submodules -p ../bin -f tree --tree-path=rib/afi-safis --tree-depth=8 --max-line-length=72 --tree-line-length=69 $name.yang > $name-rib-tree.txt.tmp`
+	response=`pyang --lint --strict --canonical -p ../../iana/yang-parameters -p ../bin/submodules -p ../bin -f tree --tree-path=rib/afi-safis --tree-depth=8 --max-line-length=72 --tree-line-length=69 $name.yang > $name-rib-tree.txt.tmp`
     else            
-        response=`pyang --ietf --strict --canonical -p ../../yang-parameters -p ../bin/submodules -p ../bin -f tree --tree-path=rib/afi-safis --tree-depth=8 --max-line-length=72 --tree-line-length=69 $name.yang > $name-rib-tree.txt.tmp`
+        response=`pyang --ietf --strict --canonical -p ../../iana/yang-parameters -p ../bin/submodules -p ../bin -f tree --tree-path=rib/afi-safis --tree-depth=8 --max-line-length=72 --tree-line-length=69 $name.yang > $name-rib-tree.txt.tmp`
     fi
     if [ $? -ne 0 ]; then
         printf "$name.yang failed generation of sub-tree diagram for rib\n"
@@ -102,7 +102,7 @@ for i in yang/example-bgp-configuration-*.xml
 do
     name=$(echo $i | cut -f 1-3 -d '.')
     echo "Validating $name.xml"
-    response=`yanglint -i -t config -p ../../yang-parameters -p ../bin -p ../bin/submodules ../../yang-parameters/ietf-network-instance@2019-01-21.yang ../bin/ietf-bgp-types\@$(date +%Y-%m-%d).yang ../bin/ietf-bgp\@$(date +%Y-%m-%d).yang $name.xml`
+    response=`yanglint -ii -t config -p ../../iana/yang-parameters -p ../bin -p ../bin/submodules ../../iana/yang-parameters/ietf-network-instance@2019-01-21.yang ../bin/ietf-bgp-types\@$(date +%Y-%m-%d).yang ../bin/ietf-bgp\@$(date +%Y-%m-%d).yang $name.xml`
     if [ $? -ne 0 ]; then
        printf "failed (error code: $?)\n"
        printf "$response\n\n"

--- a/src/yang/example-bgp-configuration-a.1.1.xml
+++ b/src/yang/example-bgp-configuration-a.1.1.xml
@@ -43,6 +43,12 @@
                     "urn:ietf:params:xml:ns:yang:ietf-bgp-types">bt:ipv4-unicast</name>
               </afi-safi>
             </afi-safis>
+	    <bfd>
+	      <enabled>true</enabled>
+	      <local-multiplier>2</local-multiplier>
+	      <desired-min-tx-interval>3300</desired-min-tx-interval>
+	      <required-min-rx-interval>3300</required-min-rx-interval>
+	    </bfd>
           </neighbor>
         </neighbors>
       </bgp>

--- a/src/yang/example-bgp-configuration-a.1.1.xml
+++ b/src/yang/example-bgp-configuration-a.1.1.xml
@@ -43,12 +43,12 @@
                     "urn:ietf:params:xml:ns:yang:ietf-bgp-types">bt:ipv4-unicast</name>
               </afi-safi>
             </afi-safis>
-	    <bfd>
-	      <enabled>true</enabled>
-	      <local-multiplier>2</local-multiplier>
-	      <desired-min-tx-interval>3300</desired-min-tx-interval>
-	      <required-min-rx-interval>3300</required-min-rx-interval>
-	    </bfd>
+            <bfd>
+              <enabled>true</enabled>
+              <local-multiplier>2</local-multiplier>
+              <desired-min-tx-interval>3300</desired-min-tx-interval>
+              <required-min-rx-interval>3300</required-min-rx-interval>
+            </bfd>
           </neighbor>
         </neighbors>
       </bgp>

--- a/src/yang/example-bgp-configuration-a.1.2.xml
+++ b/src/yang/example-bgp-configuration-a.1.2.xml
@@ -30,7 +30,7 @@
             <enabled>true</enabled>
             <secure-session-enable>true</secure-session-enable>
             <secure-session>
-	      <enable-ao>true</enable-ao>
+              <enable-ao>true</enable-ao>
               <ao-keychain>bgp-key-chain</ao-keychain>
             </secure-session>
             <peer-as>64497</peer-as>

--- a/src/yang/example-bgp-configuration-a.1.2.xml
+++ b/src/yang/example-bgp-configuration-a.1.2.xml
@@ -30,6 +30,7 @@
             <enabled>true</enabled>
             <secure-session-enable>true</secure-session-enable>
             <secure-session>
+	      <enable-ao>true</enable-ao>
               <ao-keychain>bgp-key-chain</ao-keychain>
             </secure-session>
             <peer-as>64497</peer-as>

--- a/src/yang/ietf-bgp-common.yang
+++ b/src/yang/ietf-bgp-common.yang
@@ -308,7 +308,7 @@ submodule ietf-bgp-common {
       }
       description
         "Set the local IP (either IPv4 or IPv6) address to use for
-         the session when sending BGP update messages.  This may be
+         the session when sending BGP update messages. This may be
          expressed as either an IP address or reference to the name
          of an interface.";
     }

--- a/src/yang/ietf-bgp-neighbor.yang
+++ b/src/yang/ietf-bgp-neighbor.yang
@@ -145,8 +145,8 @@ submodule ietf-bgp-neighbor {
         config false;
         description
           "This value indicates whether a particular AFI-SAFI has
-           been successfully negotiated with the peer. An AFI-SAFI may
-           be enabled in the current running configuration, but a
+           been successfully negotiated with the peer. An AFI-SAFI
+           may be enabled in the current running configuration, but a
            session restart may be required in order to negotiate the
            new capability.";
       }

--- a/src/yang/ietf-bgp-rib-tables.yang
+++ b/src/yang/ietf-bgp-rib-tables.yang
@@ -257,80 +257,6 @@ submodule ietf-bgp-rib-tables {
     }
   }
 
-  grouping ipv4-loc-rib {
-    description
-      "Top-level grouping for IPv4 routing tables.";
-    container loc-rib {
-      config false;
-      description
-        "Container for the IPv4 BGP LOC-RIB data.";
-      container routes {
-        description
-          "Enclosing container for list of routes in the routing
-           table.";
-        list route {
-          key "prefix origin path-id";
-          description
-            "List of routes in the table, keyed by the route
-             prefix, the route origin, and path-id.  The route
-             origin can be either the neighbor address from which
-             the route was learned, or the source protocol that
-             injected the route.  The path-id distinguishes routes
-             for the same prefix received from a neighbor (e.g.,
-             if add-paths is enabled).";
-          leaf prefix {
-            type inet:ipv4-prefix;
-            description
-              "The IPv4 prefix corresponding to the route.";
-          }
-          uses bgp-loc-rib-common-keys;
-          uses bgp-loc-rib-common-attr-refs;
-          uses bgp-common-route-annotations-state;
-          uses bgp-unknown-attr-top;
-          uses rib-ext-route-annotations;
-        }
-        uses clear-routes;
-      }
-    }
-  }
-
-  grouping ipv6-loc-rib {
-    description
-      "Top-level grouping for IPv6 routing tables.";
-    container loc-rib {
-      config false;
-      description
-        "Container for the IPv6 BGP LOC-RIB data.";
-      container routes {
-        description
-          "Enclosing container for list of routes in the routing
-           table.";
-        list route {
-          key "prefix origin path-id";
-          description
-            "List of routes in the table, keyed by the route
-             prefix, the route origin, and path-id.  The route
-             origin can be either the neighbor address from which
-             the route was learned, or the source protocol that
-             injected the route.  The path-id distinguishes routes
-             for the same prefix received from a neighbor (e.g.,
-             if add-paths is enabled).";
-          leaf prefix {
-            type inet:ipv6-prefix;
-            description
-              "The IPv6 prefix corresponding to the route.";
-          }
-          uses bgp-loc-rib-common-keys;
-          uses bgp-loc-rib-common-attr-refs;
-          uses bgp-common-route-annotations-state;
-          uses bgp-unknown-attr-top;
-          uses rib-ext-route-annotations;
-        }
-        uses clear-routes;
-      }
-    }
-  }
-
   grouping ipv4-adj-rib-common {
     description
       "Common structural grouping for each IPv4 adj-RIB table.";
@@ -357,7 +283,6 @@ submodule ietf-bgp-rib-tables {
         uses bgp-unknown-attr-top;
         uses rib-ext-route-annotations;
       }
-      uses clear-routes;
     }
   }
 
@@ -389,54 +314,12 @@ submodule ietf-bgp-rib-tables {
         uses bgp-unknown-attr-top;
         uses rib-ext-route-annotations;
       }
-    }
-  }
-
-  grouping ipv4-adj-rib {
-    description
-      "Top-level grouping for Adj-RIB table.";
-    container neighbors {
-      config false;
-      description
-        "Enclosing container for neighbor list.";
-      list neighbor {
-        key "neighbor-address";
+      uses clear-routes {
         description
-          "List of neighbors (peers) of the local BGP speaker.";
-        leaf neighbor-address {
-          type inet:ip-address;
-          description
-            "IP address of the BGP neighbor or peer.";
-        }
-        container adj-rib-in-pre {
-          description
-            "Per-neighbor table containing the NLRI updates
-             received from the neighbor before any local input
-             policy rules or filters have been applied.  This can
-             be considered the 'raw' updates from the neighbor.";
-          uses ipv4-adj-rib-common;
-        }
-        container adj-rib-in-post {
-          description
-            "Per-neighbor table containing the paths received from
-             the neighbor that are eligible for best-path selection
-             after local input policy rules have been applied.";
-          uses ipv4-adj-rib-in-post;
-        }
-        container adj-rib-out-pre {
-          description
-            "Per-neighbor table containing paths eligible for
-             sending (advertising) to the neighbor before output
-             policy rules have been applied.";
-          uses ipv4-adj-rib-common;
-        }
-        container adj-rib-out-post {
-          description
-            "Per-neighbor table containing paths eligible for
-             sending (advertising) to the neighbor after output
-             policy rules have been applied.";
-          uses ipv4-adj-rib-common;
-        }
+          "Clears the adj-rib-in state for the containing neighbor.
+           Subsequently, implementations might issue a
+           'route refresh' if 'route refresh' has been negotiatited,
+           or reset the session. ";
       }
     }
   }
@@ -464,7 +347,6 @@ submodule ietf-bgp-rib-tables {
         uses bgp-unknown-attr-top;
         uses rib-ext-route-annotations;
       }
-      uses clear-routes;
     }
   }
 
@@ -493,54 +375,12 @@ submodule ietf-bgp-rib-tables {
         uses bgp-unknown-attr-top;
         uses rib-ext-route-annotations;
       }
-    }
-  }
-
-  grouping ipv6-adj-rib {
-    description
-      "Top-level grouping for Adj-RIB table.";
-    container neighbors {
-      config false;
-      description
-        "Enclosing container for neighbor list.";
-      list neighbor {
-        key "neighbor-address";
+      uses clear-routes {
         description
-          "List of neighbors (peers) of the local BGP speaker.";
-        leaf neighbor-address {
-          type inet:ip-address;
-          description
-            "IP address of the BGP neighbor or peer.";
-        }
-        container adj-rib-in-pre {
-          description
-            "Per-neighbor table containing the NLRI updates
-             received from the neighbor before any local input
-             policy rules or filters have been applied.  This can
-             be considered the 'raw' updates from the neighbor.";
-          uses ipv6-adj-rib-common;
-        }
-        container adj-rib-in-post {
-          description
-            "Per-neighbor table containing the paths received from
-             the neighbor that are eligible for best-path selection
-             after local input policy rules have been applied.";
-          uses ipv6-adj-rib-in-post;
-        }
-        container adj-rib-out-pre {
-          description
-            "Per-neighbor table containing paths eligible for
-             sending (advertising) to the neighbor before output
-             policy rules have been applied.";
-          uses ipv6-adj-rib-common;
-        }
-        container adj-rib-out-post {
-          description
-            "Per-neighbor table containing paths eligible for
-             sending (advertising) to the neighbor after output
-             policy rules have been applied.";
-          uses ipv6-adj-rib-common;
-        }
+          "Clears the adj-rib-in state for the containing neighbor.
+           Subsequently, implementations might issue a
+           'route refresh' if 'route refresh' has been negotiatited,
+           or reset the session. ";
       }
     }
   }

--- a/src/yang/ietf-bgp-rib-tables.yang
+++ b/src/yang/ietf-bgp-rib-tables.yang
@@ -314,13 +314,6 @@ submodule ietf-bgp-rib-tables {
         uses bgp-unknown-attr-top;
         uses rib-ext-route-annotations;
       }
-      uses clear-routes {
-        description
-          "Clears the adj-rib-in state for the containing neighbor.
-           Subsequently, implementations might issue a
-           'route refresh' if 'route refresh' has been negotiatited,
-           or reset the session. ";
-      }
     }
   }
 
@@ -374,13 +367,6 @@ submodule ietf-bgp-rib-tables {
         uses bgp-adj-rib-in-post-route-annotations-state;
         uses bgp-unknown-attr-top;
         uses rib-ext-route-annotations;
-      }
-      uses clear-routes {
-        description
-          "Clears the adj-rib-in state for the containing neighbor.
-           Subsequently, implementations might issue a
-           'route refresh' if 'route refresh' has been negotiatited,
-           or reset the session. ";
       }
     }
   }

--- a/src/yang/ietf-bgp-rib.yang
+++ b/src/yang/ietf-bgp-rib.yang
@@ -403,9 +403,110 @@ submodule ietf-bgp-rib {
             description
               "Routing tables for IPv4 unicast -- active when the
                afi-safi name is ipv4-unicast.";
-            uses ipv4-loc-rib;
-            uses ipv4-adj-rib;
+
+            container loc-rib {
+              config false;
+              description
+                "Container for the IPv4 BGP LOC-RIB data.";
+              container routes {
+                description
+                  "Enclosing container for list of routes in the
+                   routing table.";
+                list route {
+                  key "prefix origin path-id";
+                  description
+                    "List of routes in the table, keyed by the route
+                     prefix, the route origin, and path-id. The route
+                     origin can be either the neighbor address from
+                     which the route was learned, or the source
+                     protocol that injected the route. The path-id
+                     distinguishes routes for the same prefix
+                     received from a neighbor (e.g., if add-paths is
+                     enabled).";
+                  leaf prefix {
+                    type inet:ipv4-prefix;
+                    description
+                      "The IPv4 prefix corresponding to the route.";
+                  }
+                  uses bgp-loc-rib-common-keys;
+                  uses bgp-loc-rib-common-attr-refs;
+                  uses bgp-common-route-annotations-state;
+                  uses bgp-unknown-attr-top;
+                  uses rib-ext-route-annotations;
+                }
+              }
+            }
+
+            container neighbors {
+              config false;
+              description
+                "Enclosing container for neighbor list.";
+              list neighbor {
+                key "neighbor-address";
+                description
+                  "List of neighbors (peers) of the local BGP
+                   speaker.";
+                leaf neighbor-address {
+                  type inet:ip-address;
+                  description
+                    "IP address of the BGP neighbor or peer.";
+                }
+                container adj-rib-in-pre {
+                  description
+                    "Per-neighbor table containing the NLRI updates
+                     received from the neighbor before any local
+                     input policy rules or filters have been applied.
+                     This can be considered the 'raw' updates from
+                     the neighbor.";
+                  uses ipv4-adj-rib-common;
+                  uses clear-routes {
+                    description
+                      "Clears the adj-rib-in state for the containing
+                       neighbor. Subsequently, implementations might
+                       issue a 'route refresh' if 'route refresh' has
+                       been negotiatited, or reset the session. ";
+                  }
+                }
+                container adj-rib-in-post {
+                  description
+                    "Per-neighbor table containing the paths received
+                     from the neighbor that are eligible for
+                     best-path selection after local input policy
+                     rules have been applied.";
+                  uses ipv4-adj-rib-in-post;
+                }
+                container adj-rib-out-pre {
+                  description
+                    "Per-neighbor table containing paths eligible for
+                     sending (advertising) to the neighbor before
+                     output policy rules have been applied.";
+                  uses ipv4-adj-rib-common;
+                  uses clear-routes {
+                    description
+                      "Clears the adj-rib-out state for the
+                       containing neighbor. Subsequently, neighbors
+                       will announce BGP updates to resynchronize
+                       these routes.";
+                  }
+                }
+                container adj-rib-out-post {
+                  description
+                    "Per-neighbor table containing paths eligible for
+                     sending (advertising) to the neighbor after
+                     output policy rules have been applied.";
+                  uses ipv4-adj-rib-common;
+                  uses clear-routes {
+                    description
+                      "Clears the adj-rib-out state for the
+                       containing neighbor. Subsequently, neighbors
+                       will announce BGP updates to resynchronize
+                       these routes.";
+                  }
+                }
+              }
+            }
           }
+
           container ipv6-unicast {
             when "../name = 'bt:ipv6-unicast'" {
               description
@@ -414,8 +515,108 @@ submodule ietf-bgp-rib {
             description
               "Routing tables for IPv6 unicast -- active when the
                afi-safi name is ipv6-unicast.";
-            uses ipv6-loc-rib;
-            uses ipv6-adj-rib;
+
+            container loc-rib {
+              config false;
+              description
+                "Container for the IPv6 BGP LOC-RIB data.";
+              container routes {
+                description
+                  "Enclosing container for list of routes in the
+                   routing table.";
+                list route {
+                  key "prefix origin path-id";
+                  description
+                    "List of routes in the table, keyed by the route
+                     prefix, the route origin, and path-id. The route
+                     origin can be either the neighbor address from
+                     which the route was learned, or the source
+                     protocol that injected the route. The path-id
+                     distinguishes routes for the same prefix
+                     received from a neighbor (e.g., if add-paths is
+                     enabled).";
+                  leaf prefix {
+                    type inet:ipv6-prefix;
+                    description
+                      "The IPv6 prefix corresponding to the route.";
+                  }
+                  uses bgp-loc-rib-common-keys;
+                  uses bgp-loc-rib-common-attr-refs;
+                  uses bgp-common-route-annotations-state;
+                  uses bgp-unknown-attr-top;
+                  uses rib-ext-route-annotations;
+                }
+              }
+            }
+
+            container neighbors {
+              config false;
+              description
+                "Enclosing container for neighbor list.";
+              list neighbor {
+                key "neighbor-address";
+                description
+                  "List of neighbors (peers) of the local BGP
+                   speaker.";
+                leaf neighbor-address {
+                  type inet:ip-address;
+                  description
+                    "IP address of the BGP neighbor or peer.";
+                }
+                container adj-rib-in-pre {
+                  description
+                    "Per-neighbor table containing the NLRI updates
+                     received from the neighbor before any local
+                     input policy rules or filters have been applied.
+                     This can be considered the 'raw' updates from
+                     the neighbor.";
+                  uses ipv6-adj-rib-common;
+                  uses clear-routes {
+                    description
+                      "Clears the adj-rib-in state for the containing
+                       neighbor. Subsequently, implementations might
+                       issue a 'route refresh' if 'route refresh' has
+                       been negotiatited, or reset the session. ";
+                  }
+                }
+                container adj-rib-in-post {
+                  description
+                    "Per-neighbor table containing the paths received
+                     from the neighbor that are eligible for
+                     best-path selection after local input policy
+                     rules have been applied.";
+                  uses ipv6-adj-rib-in-post;
+                }
+                container adj-rib-out-pre {
+                  description
+                    "Per-neighbor table containing paths eligible for
+                     sending (advertising) to the neighbor before
+                     output policy rules have been applied.";
+                  uses ipv6-adj-rib-common;
+                  uses clear-routes {
+                    description
+                      "Clears the adj-rib-out state for the
+                       containing neighbor. Subsequently, neighbors
+                       will announce BGP updates to resynchronize
+                       these routes.";
+                  }
+                }
+                container adj-rib-out-post {
+                  description
+                    "Per-neighbor table containing paths eligible for
+                     sending (advertising) to the neighbor after
+                     output policy rules have been applied.";
+                  uses ipv6-adj-rib-common;
+                  uses clear-routes {
+                    description
+                      "Clears the adj-rib-out state for the
+                       containing neighbor. Subsequently, neighbors
+                       will announce BGP updates to resynchronize
+                       these routes.";
+                  }
+                }
+              }
+            }
           }
         }
       }

--- a/src/yang/ietf-bgp-rib.yang
+++ b/src/yang/ietf-bgp-rib.yang
@@ -474,6 +474,13 @@ submodule ietf-bgp-rib {
                      best-path selection after local input policy
                      rules have been applied.";
                   uses ipv4-adj-rib-in-post;
+                  uses clear-routes {
+                    description
+                      "Clears the adj-rib-in state for the containing
+                       neighbor. Subsequently, implementations might
+                       issue a 'route refresh' if 'route refresh' has
+                       been negotiatited, or reset the session. ";
+                  }
                 }
                 container adj-rib-out-pre {
                   description
@@ -586,6 +593,13 @@ submodule ietf-bgp-rib {
                      best-path selection after local input policy
                      rules have been applied.";
                   uses ipv6-adj-rib-in-post;
+                  uses clear-routes {
+                    description
+                      "Clears the adj-rib-in state for the containing
+                       neighbor. Subsequently, implementations might
+                       issue a 'route refresh' if 'route refresh' has
+                       been negotiatited, or reset the session. ";
+                  }
                 }
                 container adj-rib-out-pre {
                   description

--- a/src/yang/ietf-bgp.yang
+++ b/src/yang/ietf-bgp.yang
@@ -658,6 +658,17 @@ module ietf-bgp {
                with the neighbor";
             uses bgp-neighbor-afi-safi-list;
           }
+
+	  container bfd {
+            if-feature "bt:bfd";
+            uses bfd-types:client-cfg-parms;
+            description
+              "BFD client configuration.";
+            reference
+              "RFC BBBB - YANG Data Model for Bidirectional Forwarding
+               Detection.";
+          }
+
           container statistics {
             description
               "Statistics per neighbor.";

--- a/src/yang/ietf-bgp.yang
+++ b/src/yang/ietf-bgp.yang
@@ -950,15 +950,6 @@ module ietf-bgp {
               "Reference to the interface within the routing
                instance.";
           }
-          container bfd {
-            if-feature "bt:bfd";
-            uses bfd-types:client-cfg-parms;
-            description
-              "BFD client configuration.";
-            reference
-              "RFC 9127, YANG Data Model for Bidirectional Forwarding
-               Detection.";
-          }
           description
             "List of interfaces within the routing instance.";
         }

--- a/src/yang/ietf-bgp.yang
+++ b/src/yang/ietf-bgp.yang
@@ -659,13 +659,13 @@ module ietf-bgp {
             uses bgp-neighbor-afi-safi-list;
           }
 
-	  container bfd {
+          container bfd {
             if-feature "bt:bfd";
             uses bfd-types:client-cfg-parms;
             description
               "BFD client configuration.";
             reference
-              "RFC BBBB - YANG Data Model for Bidirectional Forwarding
+              "RFC 9127, YANG Data Model for Bidirectional Forwarding
                Detection.";
           }
 
@@ -950,7 +950,7 @@ module ietf-bgp {
             description
               "BFD client configuration.";
             reference
-              "RFC BBBB - YANG Data Model for Bidirectional Forwarding
+              "RFC 9127, YANG Data Model for Bidirectional Forwarding
                Detection.";
           }
           description


### PR DESCRIPTION
This PR addresses item #87. It adds a description statement under every use of the 'clear-route' grouping as to what it is clearing.

What was discussed on the call did not include what happens with ipv* adj-rib-in-post. Added a 'clear-route' option for that also.

Finally, refactored the grouping ipv*-loc-rib and ipv*-adj-rib grouping out as it was being used only once.