### PR TITLE
Issue 142: Temporarily delete RFC9127 files coming from IANA's yang-parameters registry

### DIFF
--- a/src/validate-and-gen-trees.sh
+++ b/src/validate-and-gen-trees.sh
@@ -5,6 +5,8 @@
 #
 if [ ! -d ../../yang-parameters ]; then
    rsync -avz --delete rsync.iana.org::assignments/yang-parameters ../../
+# Temporary workaround for IANA RFC 9127 issues
+rm ../../yang-parameters/*bfd*
 fi
 
 for i in ../bin/ietf-*\@$(date +%Y-%m-%d).yang


### PR DESCRIPTION
Temporary workaround for removing bfd files from yang-parameters directory due to corruption at IANA.
Let's pyang in the build system work.