### PR TITLE
Issue 86: Per-client bfd configuration

### DIFF
--- a/src/yang/ietf-bgp-common.yang
+++ b/src/yang/ietf-bgp-common.yang
@@ -14,6 +14,12 @@ submodule ietf-bgp-common {
     reference
       "RFC 6991: Common YANG Data Types.";
   }
+  import ietf-bfd-types {
+    prefix bfd-types;
+    reference
+      "RFC 9127, YANG Data Model for Bidirectional Forward
+       Detection.";
+  }
 
   organization
     "IETF IDR Working Group";
@@ -312,7 +318,6 @@ submodule ietf-bgp-common {
          expressed as either an IP address or reference to the name
          of an interface.";
     }
-
     leaf md5-auth-password {
       type string;
       description
@@ -321,6 +326,15 @@ submodule ietf-bgp-common {
       reference
         "RFC 2385: Protection of BGP Sessions via the TCP MD5
                    Signature Option.";
+    }
+    container bfd {
+      if-feature "bt:bfd";
+      uses bfd-types:client-cfg-parms;
+      description
+        "BFD client configuration.";
+      reference
+        "RFC 9127, YANG Data Model for Bidirectional Forwarding
+         Detection.";
     }
   }
 

--- a/src/yang/ietf-bgp-common.yang
+++ b/src/yang/ietf-bgp-common.yang
@@ -17,7 +17,7 @@ submodule ietf-bgp-common {
   import ietf-bfd-types {
     prefix bfd-types;
     reference
-      "RFC 9127, YANG Data Model for Bidirectional Forward
+      "RFC XXXX, YANG Data Model for Bidirectional Forward
        Detection.";
   }
 
@@ -333,7 +333,7 @@ submodule ietf-bgp-common {
       description
         "BFD client configuration.";
       reference
-        "RFC 9127, YANG Data Model for Bidirectional Forwarding
+        "RFC XXXX, YANG Data Model for Bidirectional Forwarding
          Detection.";
     }
   }

--- a/src/yang/ietf-bgp.yang
+++ b/src/yang/ietf-bgp.yang
@@ -28,12 +28,6 @@ module ietf-bgp {
     reference
       "RFC XXXX, BGP YANG Model for Service Provider Network.";
   }
-  import ietf-bfd-types {
-    prefix bfd-types;
-    reference
-      "RFC BBBB, YANG Data Model for Bidirectional Forward
-       Detection.";
-  }
   import ietf-inet-types {
     prefix inet;
     reference
@@ -938,15 +932,6 @@ module ietf-bgp {
             description
               "Reference to the interface within the routing
                instance.";
-          }
-          container bfd {
-            if-feature "bt:bfd";
-            uses bfd-types:client-cfg-parms;
-            description
-              "BFD client configuration.";
-            reference
-              "RFC 9127, YANG Data Model for Bidirectional Forwarding
-               Detection.";
           }
           description
             "List of interfaces within the routing instance.";


### PR DESCRIPTION
After the discussion that resulted in RFC9127-bis in BFD, the fix here
is to simply move the grouping to the transport parameters.