### PR TITLE
Issue 80: Add large bgp communities to models.

### DIFF
--- a/src/yang/ietf-bgp-commands.yang
+++ b/src/yang/ietf-bgp-commands.yang
@@ -33,6 +33,7 @@ module ietf-bgp-commands {
     uses bgp:attr-set-attributes;
     uses bgp:bgp-community-attr-state;
     uses bgp:ext-community-attributes;
+    uses bgp:large-community-attributes;
     uses bgp:bgp-common-route-annotations-state;
     uses bgp:bgp-unknown-attr-top;
     uses bgp:rib-ext-route-annotations;
@@ -45,6 +46,7 @@ module ietf-bgp-commands {
     uses bgp:attr-set-attributes;
     uses bgp:bgp-community-attr-state;
     uses bgp:ext-community-attributes;
+    uses bgp:large-community-attributes;
     uses bgp:bgp-common-route-annotations-state;
     uses bgp:bgp-unknown-attr-top;
     uses bgp:rib-ext-route-annotations;
@@ -57,6 +59,7 @@ module ietf-bgp-commands {
     uses bgp:attr-set-attributes;
     uses bgp:bgp-community-attr-state;
     uses bgp:ext-community-attributes;
+    uses bgp:large-community-attributes;
     uses bgp:bgp-common-route-annotations-state;
     uses bgp:bgp-unknown-attr-top;
     uses bgp:rib-ext-route-annotations;
@@ -69,6 +72,7 @@ module ietf-bgp-commands {
     uses bgp:attr-set-attributes;
     uses bgp:bgp-community-attr-state;
     uses bgp:ext-community-attributes;
+    uses bgp:large-community-attributes;
     uses bgp:bgp-common-route-annotations-state;
     uses bgp:bgp-unknown-attr-top;
     uses bgp:rib-ext-route-annotations;
@@ -81,6 +85,7 @@ module ietf-bgp-commands {
     uses bgp:attr-set-attributes;
     uses bgp:bgp-community-attr-state;
     uses bgp:ext-community-attributes;
+    uses bgp:large-community-attributes;
     uses bgp:bgp-common-route-annotations-state;
     uses bgp:bgp-unknown-attr-top;
     uses bgp:rib-ext-route-annotations;
@@ -92,6 +97,7 @@ module ietf-bgp-commands {
     uses bgp:attr-set-attributes;
     uses bgp:bgp-community-attr-state;
     uses bgp:ext-community-attributes;
+    uses bgp:large-community-attributes;
     uses bgp:bgp-common-route-annotations-state;
     uses bgp:bgp-unknown-attr-top;
     uses bgp:rib-ext-route-annotations;
@@ -104,6 +110,7 @@ module ietf-bgp-commands {
     uses bgp:attr-set-attributes;
     uses bgp:bgp-community-attr-state;
     uses bgp:ext-community-attributes;
+    uses bgp:large-community-attributes;
     uses bgp:bgp-common-route-annotations-state;
     uses bgp:bgp-unknown-attr-top;
     uses bgp:rib-ext-route-annotations;
@@ -116,6 +123,7 @@ module ietf-bgp-commands {
     uses bgp:attr-set-attributes;
     uses bgp:bgp-community-attr-state;
     uses bgp:ext-community-attributes;
+    uses bgp:large-community-attributes;
     uses bgp:bgp-common-route-annotations-state;
     uses bgp:bgp-unknown-attr-top;
     uses bgp:rib-ext-route-annotations;
@@ -128,6 +136,7 @@ module ietf-bgp-commands {
     uses bgp:attr-set-attributes;
     uses bgp:bgp-community-attr-state;
     uses bgp:ext-community-attributes;
+    uses bgp:large-community-attributes;
     uses bgp:bgp-common-route-annotations-state;
     uses bgp:bgp-unknown-attr-top;
     uses bgp:rib-ext-route-annotations;
@@ -140,6 +149,7 @@ module ietf-bgp-commands {
     uses bgp:attr-set-attributes;
     uses bgp:bgp-community-attr-state;
     uses bgp:ext-community-attributes;
+    uses bgp:large-community-attributes;
     uses bgp:bgp-common-route-annotations-state;
     uses bgp:bgp-unknown-attr-top;
     uses bgp:rib-ext-route-annotations;

--- a/src/yang/ietf-bgp-policy.yang
+++ b/src/yang/ietf-bgp-policy.yang
@@ -601,7 +601,7 @@ module ietf-bgp-policy {
         description
           "Action to set the large community attributes of the
            route, along with options to modify how the community is
-           modified. Extended communities may be set using an inline
+           modified. Large communities may be set using an inline
            list OR a reference to an existing defined set (but not
            both).";
 

--- a/src/yang/ietf-bgp-policy.yang
+++ b/src/yang/ietf-bgp-policy.yang
@@ -203,6 +203,30 @@ module ietf-bgp-policy {
           }
         }
       }
+      container large-community-sets {
+        description
+          "Enclosing container for list of large BGP community
+           sets";
+        list large-community-set {
+          key "name";
+          description
+            "List of defined large BGP community sets";
+          leaf name {
+            type string;
+            description
+              "Name / label of the large community set -- this is
+               used to reference the set in match conditions";
+          }
+          leaf-list member {
+            type union {
+              type bt:bgp-large-community-type;
+              type bt:bgp-community-regexp-type;
+            }
+            description
+              "Members of the large community set.";
+          }
+        }
+      }
       container as-path-sets {
         description
           "Enclosing container for list of define AS path sets.";
@@ -408,6 +432,22 @@ module ietf-bgp-policy {
         }
         uses rt-pol:match-set-options-group;
       }
+
+      container match-large-community-set {
+        description
+          "Match a referenced large community-set according to the
+           logic defined in the match-set-options leaf.";
+        leaf ext-community-set {
+          type leafref {
+            path "/rt-pol:routing-policy/rt-pol:defined-sets/"
+               + "bp:bgp-defined-sets/bp:large-community-sets/"
+               + "bp:large-community-set/bp:name";
+          }
+          description
+            "References a defined large community set.";
+        }
+        uses rt-pol:match-set-options-group;
+      }
       container match-as-path-set {
         description
           "Match a referenced as-path set according to the logic
@@ -536,10 +576,7 @@ module ietf-bgp-policy {
              communities for the set-ext-community action";
           case inline {
             leaf-list communities {
-              type union {
-                type rt-types:route-target;
-                type bt:bgp-well-known-community-type;
-              }
+              type rt-types:route-target;
               description
                 "Set the extended community values for the update
                  inline with a list.";
@@ -551,6 +588,49 @@ module ietf-bgp-policy {
                 path "/rt-pol:routing-policy/rt-pol:defined-sets/"
                    + "bp:bgp-defined-sets/bp:ext-community-sets/"
                    + "bp:ext-community-set/bp:name";
+              }
+              description
+                "References a defined extended community set by
+                 name.";
+            }
+          }
+        }
+      }
+
+      container set-large-community {
+        description
+          "Action to set the large community attributes of the
+           route, along with options to modify how the community is
+           modified. Extended communities may be set using an inline
+           list OR a reference to an existing defined set (but not
+           both).";
+
+        leaf options {
+          type bgp-set-community-option-type;
+          description
+            "Options for modifying the community attribute with
+             the specified values.  These options apply to both
+             methods of setting the community attribute.";
+        }
+
+        choice method {
+          description
+            "Indicates the method used to specify the large
+             communities for the set-large-community action";
+          case inline {
+            leaf-list communities {
+              type bt:bgp-large-community-type;
+              description
+                "Set the large community values for the update
+                 inline with a list.";
+            }
+          }
+          case reference {
+            leaf large-community-set-ref {
+              type leafref {
+                path "/rt-pol:routing-policy/rt-pol:defined-sets/"
+                   + "bp:bgp-defined-sets/bp:large-community-sets/"
+                   + "bp:large-community-set/bp:name";
               }
               description
                 "References a defined extended community set by

--- a/src/yang/ietf-bgp-policy.yang
+++ b/src/yang/ietf-bgp-policy.yang
@@ -609,7 +609,7 @@ module ietf-bgp-policy {
           type bgp-set-community-option-type;
           description
             "Options for modifying the community attribute with
-             the specified values.  These options apply to both
+             the specified values. These options apply to both
              methods of setting the community attribute.";
         }
 

--- a/src/yang/ietf-bgp-rib.yang
+++ b/src/yang/ietf-bgp-rib.yang
@@ -405,7 +405,7 @@ submodule ietf-bgp-rib {
           leaf index {
             type uint64;
             description
-              "System generated index for each attribute set.  The
+              "System generated index for each attribute set. The
                index is used to reference an attribute set from a
                specific path.  Multiple paths may reference the same
                attribute set.";

--- a/src/yang/ietf-bgp-rib.yang
+++ b/src/yang/ietf-bgp-rib.yang
@@ -317,7 +317,7 @@ submodule ietf-bgp-rib {
 
   grouping ext-community-attributes {
     description
-      "A grouping for all external community parameters.";
+      "A grouping for all extended community parameters.";
 
     leaf-list ext-community {
       type rt:route-target;
@@ -328,6 +328,19 @@ submodule ietf-bgp-rib {
          formatted according to RFC 4360.";
       reference
         "RFC 4360 - BGP Extended Communities Attribute";
+    }
+  }
+
+  grouping large-community-attributes {
+    description
+      "A grouping for all large community parameters.";
+
+    leaf-list large-community {
+      type bt:bgp-large-community-type;
+      description
+        "List of BGP large community attributes.";
+      reference
+        "RFC 8092 - BGP Large Communities Attribute";
     }
   }
   
@@ -377,6 +390,27 @@ submodule ietf-bgp-rib {
                attribute set.";
           }
           uses ext-community-attributes;
+        }
+      }
+      container large-communities {
+        description
+          "Enclosing container for the list of large community
+           attribute sets.";
+        list large-community {
+          key "index";
+          config false;
+          description
+            "List of path attributes that may be in use by multiple
+             routes in the table.";
+          leaf index {
+            type uint64;
+            description
+              "System generated index for each attribute set.  The
+               index is used to reference an attribute set from a
+               specific path.  Multiple paths may reference the same
+               attribute set.";
+          }
+          uses large-community-attributes;
         }
       }
 

--- a/src/yang/ietf-bgp-rib.yang
+++ b/src/yang/ietf-bgp-rib.yang
@@ -340,7 +340,7 @@ submodule ietf-bgp-rib {
       description
         "List of BGP large community attributes.";
       reference
-        "RFC 8092 - BGP Large Communities Attribute";
+        "RFC 8092: BGP Large Communities Attribute.";
     }
   }
   

--- a/src/yang/ietf-bgp-types.yang
+++ b/src/yang/ietf-bgp-types.yang
@@ -504,6 +504,22 @@ module ietf-bgp-types {
       "RFC 4271 - A Border Gateway Protocol 4 (BGP-4), Sec 4.3";
   }
 
+  typedef bgp-large-community-type {
+    type string {
+      // 4-octets global:4-octets local part-1:4-octets local part-2.
+      pattern '(4[0-2][0-9][0-4][0-9][0-6][0-7][0-2][0-9][0-6]|'
+            + '[1-3][0-9]{9}|[1-9]([0-9]{1,7})?[0-9]|[1-9]):'
+            + '(4[0-2][0-9][0-4][0-9][0-6][0-7][0-2][0-9][0-6]|'
+            + '[1-3][0-9]{9}|[1-9]([0-9]{1,7})?[0-9]|[1-9]):'
+            + '(4[0-2][0-9][0-4][0-9][0-6][0-7][0-2][0-9][0-6]|'
+            + '[1-3][0-9]{9}|[1-9]([0-9]{1,7})?[0-9]|[1-9])';
+    }
+    description
+      "Type definition for a large BGP community";
+    reference
+          "RFC 8092: BGP Large Communities Attribute.";
+  }
+
   typedef peer-type {
     type enumeration {
       enum internal {

--- a/src/yang/ietf-bgp-types.yang
+++ b/src/yang/ietf-bgp-types.yang
@@ -517,7 +517,7 @@ module ietf-bgp-types {
     description
       "Type definition for a large BGP community";
     reference
-          "RFC 8092: BGP Large Communities Attribute.";
+      "RFC 8092: BGP Large Communities Attribute.";
   }
 
   typedef peer-type {


### PR DESCRIPTION
Add large bgp communities to models

Incidentally also fix an issue with extended communities to not include
the well known regular community types.

Closes #80 