### PR TITLE
Issue 60: Restructure graceful restart to properly reflect forwarding…

### DIFF
--- a/src/yang/ietf-bgp-neighbor.yang
+++ b/src/yang/ietf-bgp-neighbor.yang
@@ -190,6 +190,35 @@ submodule ietf-bgp-neighbor {
             "This leaf indicates whether the ability to support
              graceful-restart has been advertised to the peer";
         }
+        leaf local-forwarding-state-preserved {
+          type boolean;
+          config false;
+          description
+            "This leaf indicates whether the local router has
+             or would advertise the Forwarding State bit in its
+             Graceful Restart capability for this AFI-SAFI.";
+          reference
+            "RFC 4724: Graceful Restart Mechanism for BGP.";
+        }
+        leaf forwarding-state-preserved {
+          type boolean;
+          config false;
+          description
+            "This leaf indicates whether the neighbor has advertised
+             the Forwarding State bit in its Graceful Restart
+             capability for this AFI-SAFI.";
+          reference
+            "RFC 4724: Graceful Restart Mechanism for BGP.";
+        }
+        leaf end-of-rib-received {
+          type boolean;
+          config false;
+          description
+            "This leaf indicates whether the neighbor has advertised
+             the End-of-RIB marker for this AFI-SAFI.";
+          reference
+            "RFC 4724: Graceful Restart Mechanism for BGP.";
+        }
       }
       uses mp-all-afi-safi-list-contents;
       uses bgp-neighbor-use-multiple-paths;

--- a/src/yang/ietf-bgp.yang
+++ b/src/yang/ietf-bgp.yang
@@ -615,38 +615,10 @@ module ietf-bgp {
               type boolean;
               config false;
               description
-                "This flag indicates whether the local neighbor is
+                "This flag indicates whether this BGP session is
                  currently restarting. The flag is cleared after all
                  NLRI have been advertised to the peer, and the
                  End-of-RIB (EOR) marker has been cleared.";
-            }
-            leaf mode {
-              type enumeration {
-                enum helper-only {
-                  description
-                    "The local router is operating in helper-only
-                     mode, and hence will not retain forwarding state
-                     during a local session restart, but will do so
-                     during a restart of the remote peer";
-                }
-                enum bilateral {
-                  description
-                    "The local router is operating in both helper
-                     mode, and hence retains forwarding state during
-                     a remote restart, and also maintains forwarding
-                     state during local session restart";
-                }
-                enum remote-helper {
-                  description
-                    "The local system is able to retain routes during
-                     restart but the remote system is only able to
-                     act as a helper";
-                }
-              }
-              config false;
-              description
-                "This leaf indicates the mode of operation of BGP
-                 graceful restart with the peer";
             }
           }
           uses structure-neighbor-group-logging-options;


### PR DESCRIPTION
… state

Acee Lindem flagged during YANG doctor review that the "mode" leaf
didn't quite cover proper forwarding state preservation semantics.
Related IDR list followup discussed how this state also needed to be
per-AFI-SAFI.

The fix was primarily to remove it from global scope and make it
per-neighbor, per AFI-SAFI state.

While I was in there, I also added a flag to indicate whether End-of-RIB
was received from the peer for that AFI-SAFI.  This is a core bit of
useful troubleshooting infrastructure most implementations have for the
graceful restart feature.

Closes #60