### PR TITLE
Issue 59: Remove ipsec case from secure transport

### DIFF
--- a/src/yang/ietf-bgp.yang
+++ b/src/yang/ietf-bgp.yang
@@ -429,19 +429,6 @@ module ietf-bgp {
                   "RFC 5925: The TCP Authentication Option.";
               }
 
-              case ipsec {
-                leaf sa {
-                  type string;
-                  description
-                    "Security Association (SA) name.";
-                }
-                description
-                  "Currently, the IPsec/IKE YANG model has no
-                   grouping defined that this model can use. When
-                   such a grouping is defined, this model can import
-                   the grouping to add the key parameters
-                   needed to kick of IKE.";
-              }
               description
                 "Choice of authentication options.";
             }


### PR DESCRIPTION
Remove ipsec configuration for the time being.  It's not widely supported in the current semantic.

Closes #59 