### PR TITLE
Add a policy example

### DIFF
--- a/draft/draft-ietf-idr-bgp-model.xml
+++ b/draft/draft-ietf-idr-bgp-model.xml
@@ -945,14 +945,11 @@ INSERT_TEXT_FROM_FILE(../src/yang/example-bgp-configuration-a.1.3.xml,68)
         R1, R2, and R3, configured with AS value of 1, 2 and 3 
         respectively. R1 advertises 5 prefixes to R2 and R3, as
         shown below.</t>
-          <dl newline="true" spacing="normal" indent="3">
-	    <dt>1.1.1.1/32 and 2.2.2.2/32</dt>
-	    <dd>community 11:11</dd>
-	    <dt>3.3.3.3/32 and 4.4.4.4/32</dt>
-	    <dd>community 11:11 22:22</dd>
-	    <dt>5.5.5.5/32</dt>
-	    <dd>community 33.33</dd>
-	</dl>
+        <ul spacing="normal" indent="3">
+	  <li>1.1.1.1/32 and 2.2.2.2/32 with community 11:11</li>
+	  <li>3.3.3.3/32 and 4.4.4.4/32 with community 11:11 22:22</li>
+	  <li>5.5.5.5/32 with community 33.33</li>
+	</ul>
 	<t>Route Policy TO_R2 defines the policy that R1 uses
         in route updates towards R2. It consists of three statements,
         statement 10 that has a exact match rule for the prefix

--- a/draft/draft-ietf-idr-bgp-model.xml
+++ b/draft/draft-ietf-idr-bgp-model.xml
@@ -933,6 +933,43 @@ INSERT_TEXT_FROM_FILE(../src/yang/example-bgp-configuration-a.1.3.xml,68)
 ]]></artwork>
         </figure>
       </section>
+      <section title="BGP Policy">
+        <t>Routing policy using community value involves configuring
+	rules to match community values in the inbound or outbound
+	direction. In this example, which is heavily borrowed from
+	the example on the Cisco community page, we look at
+	"match community exact" match, which happens only when BGP
+	updates have the same community values as specified in the
+	community list.</t>
+	<t>The topology in this example consists of three routers,
+        R1, R2, and R3, configured with AS value of 1, 2 and 3 
+        respectively. R1 advertises 5 prefixes to R2 and R3, as
+        shown below.</t>
+          <dl newline="true" spacing="normal" indent="3">
+	    <dt>1.1.1.1/32 and 2.2.2.2/32</dt>
+	    <dd>community 11:11</dd>
+	    <dt>3.3.3.3/32 and 4.4.4.4/32</dt>
+	    <dd>community 11:11 22:22</dd>
+	    <dt>5.5.5.5/32</dt>
+	    <dd>community 33.33</dd>
+	</dl>
+	<t>Route Policy TO_R2 defines the policy that R1 uses
+        in route updates towards R2. It consists of three statements,
+        statement 10 that has a exact match rule for the prefix
+        list L0andL1, and a set-community action for 11:11. 
+        The second statement, statement 20, consists of an
+        exact match rule for prefix list L2andL3, with a set
+        community action for 11:11 22:22. The final statement,
+        statement 30, consists of an exact match rule for prefix
+        list L4, with a set community action for 33:33. </t>
+
+        <figure>
+          <artwork><![CDATA[
+INSERT_TEXT_FROM_FILE(../src/yang/example-bgp-configuration-a.1.4.xml,68)
+
+]]></artwork>
+        </figure>
+      </section>
     </section>
 
     <section title="How to add a new AFI and Augment a Module">

--- a/draft/draft-ietf-idr-bgp-model.xml
+++ b/draft/draft-ietf-idr-bgp-model.xml
@@ -947,18 +947,19 @@ INSERT_TEXT_FROM_FILE(../src/yang/example-bgp-configuration-a.1.3.xml,68)
         shown below.</t>
         <ul spacing="normal" indent="3">
 	  <li>1.1.1.1/32 and 2.2.2.2/32 with community 11:11</li>
-	  <li>3.3.3.3/32 and 4.4.4.4/32 with community 11:11 22:22</li>
+	  <li>3.3.3.3/32 and 4.4.4.4/32 with community 11:11 and
+	  22:22</li>
 	  <li>5.5.5.5/32 with community 33.33</li>
 	</ul>
-	<t>Route Policy TO_R2 defines the policy that R1 uses
-        in route updates towards R2. It consists of three statements,
-        statement 10 that has a exact match rule for the prefix
-        list L0andL1, and a set-community action for 11:11. 
-        The second statement, statement 20, consists of an
-        exact match rule for prefix list L2andL3, with a set
-        community action for 11:11 22:22. The final statement,
-        statement 30, consists of an exact match rule for prefix
-        list L4, with a set community action for 33:33. </t>
+	<t>Route Policy TO_R2 defines the policy that R1 uses in route
+	updates towards R2. It consists of three statements, statement
+	10 that has a exact match rule for the prefix list L0andL1,
+	and a set-community action of add for 11:11.  The second
+	statement, statement 20, consists of an exact match rule for
+	prefix list L2andL3, with a set community action of remove for
+	11:11 22:22. The final statement, statement 30, consists of an
+	exact match rule for prefix list L4, with a set community
+	action of replace for 33:33.</t>
 
         <figure>
           <artwork><![CDATA[

--- a/src/validate-and-gen-trees.sh
+++ b/src/validate-and-gen-trees.sh
@@ -99,11 +99,26 @@ rm ../bin/*-rib-tree.txt.tmp
 
 echo "Validating examples"
 
-for i in yang/example-bgp-configuration-a.*.xml
+# Validate BGP examples
+for i in yang/example-bgp-configuration-a.1.[0-3].xml
 do
     name=$(echo $i | cut -f 1-3 -d '.')
     echo "Validating $name.xml"
     response=`yanglint -ii -t config -p ../../iana/yang-parameters -p ../bin -p ../bin/submodules ../../iana/yang-parameters/ietf-network-instance@2019-01-21.yang ../bin/ietf-bgp-types\@$(date +%Y-%m-%d).yang ../bin/ietf-bgp\@$(date +%Y-%m-%d).yang $name.xml`
+    if [ $? -ne 0 ]; then
+       printf "failed (error code: $?)\n"
+       printf "$response\n\n"
+       echo
+       exit 1
+    fi
+done
+
+# Validate BGP Policy examples
+for i in yang/example-bgp-configuration-a.1.4.xml
+do
+    name=$(echo $i | cut -f 1-3 -d '.')
+    echo "Validating $name.xml"
+    response=`yanglint -ii -t config -p ../../iana/yang-parameters -p ../bin -p ../bin/submodules ../../iana/yang-parameters/ietf-network-instance@2019-01-21.yang ../bin/ietf-bgp-types\@$(date +%Y-%m-%d).yang ../bin/ietf-bgp\@$(date +%Y-%m-%d).yang ../bin/ietf-bgp-policy\@$(date +%Y-%m-%d).yang $name.xml`
     if [ $? -ne 0 ]; then
        printf "failed (error code: $?)\n"
        printf "$response\n\n"

--- a/src/yang/example-bgp-configuration-a.1.4.xml
+++ b/src/yang/example-bgp-configuration-a.1.4.xml
@@ -19,6 +19,30 @@
 	    </prefix>
 	  </prefixes>
 	</prefix-set>
+	<prefix-set>
+	  <name>L2andL3</name>
+	  <mode>ipv4-mode</mode>
+	  <prefixes>
+	    <prefix>
+	      <ip-prefix>3.3.3.3/32</ip-prefix>
+	      <masklength-range>exact</masklength-range>
+	    </prefix>
+	    <prefix>
+	      <ip-prefix>4.4.4.4/32</ip-prefix>
+	      <masklength-range>exact</masklength-range>
+	    </prefix>
+	  </prefixes>
+	</prefix-set>
+	<prefix-set>
+	  <name>L5</name>
+	  <mode>ipv4-mode</mode>
+	  <prefixes>
+	    <prefix>
+	      <ip-prefix>5.5.5.5/32</ip-prefix>
+	      <masklength-range>exact</masklength-range>
+	    </prefix>
+	  </prefixes>
+	</prefix-set>
       </prefix-sets>
     </bgp-defined-sets>
   </defined-sets>
@@ -41,6 +65,46 @@
 		<method>inline</method>
 		<inline>
 		  <communities>11:11</communities>
+		</inline>
+	      </set-community>
+	    </bgp-actions>
+	  </actions>
+	</statement>
+	<statement>
+	  <name>20</name>
+	  <conditions>
+	    <match-prefix-set
+		xmlns="urn:ietf:params:xml:ns:yang:ietf-bgp-policy">
+	      <prefix-set>L2andL3</prefix-set>
+	    </match-prefix-set>
+	  </conditions>
+	  <actions>
+	    <bgp-actions
+		xmlns="urn:ietf:params:xml:ns:yang:ietf-bgp-policy">
+	      <set-community>
+		<method>inline</method>
+		<inline>
+		  <communities>11:11 22:22</communities>
+		</inline>
+	      </set-community>
+	    </bgp-actions>
+	  </actions>
+	</statement>
+	<statement>
+	  <name>30</name>
+	  <conditions>
+	    <match-prefix-set
+		xmlns="urn:ietf:params:xml:ns:yang:ietf-bgp-policy">
+	      <prefix-set>L4</prefix-set>
+	    </match-prefix-set>
+	  </conditions>
+	  <actions>
+	    <bgp-actions
+		xmlns="urn:ietf:params:xml:ns:yang:ietf-bgp-policy">
+	      <set-community>
+		<method>inline</method>
+		<inline>
+		  <communities>33:33</communities>
 		</inline>
 	      </set-community>
 	    </bgp-actions>

--- a/src/yang/example-bgp-configuration-a.1.4.xml
+++ b/src/yang/example-bgp-configuration-a.1.4.xml
@@ -2,25 +2,24 @@
 <routing-policy
     xmlns="urn:ietf:params:xml:ns:yang:ietf-routing-policy">
   <defined-sets>
-    <bgp-defined-sets>
+    <bgp-defined-sets
+	xmlns="urn:ietf:params:xml:ns:yang:ietf-bgp-policy">
       <prefix-sets>
 	<prefix-set>
-	  <name>L0 and L1</name>
+	  <name>L0andL1</name>
 	  <mode>ipv4-mode</mode>
 	  <prefixes>
 	    <prefix>
 	      <ip-prefix>1.1.1.1/32</ip-prefix>
 	      <masklength-range>exact</masklength-range>
 	    </prefix>
+	    <prefix>
+	      <ip-prefix>2.2.2.2/32</ip-prefix>
+	      <masklength-range>exact</masklength-range>
+	    </prefix>
 	  </prefixes>
 	</prefix-set>
       </prefix-sets>
-      <community-sets>
-	<community-set>
-	  <name>TO_R2</name>
-	  <member>What should this be?</member>
-	</community-set>
-      </community-sets>
     </bgp-defined-sets>
   </defined-sets>
   <policy-definitions>
@@ -28,15 +27,64 @@
       <name>TO_R2</name>
       <statements>
 	<statement>
-	  <name>TO_R2</name>
+	  <name>10</name>
+	  <conditions>
+	    <match-prefix-set
+		xmlns="urn:ietf:params:xml:ns:yang:ietf-bgp-policy">
+	      <prefix-set>L0andL1</prefix-set>
+	    </match-prefix-set>
+	  </conditions>
 	  <actions>
-	    <set-community>
-	      <option>add</option>
-	      <community-set-ref>TO_R2</community-set-ref>
-	    </set-community>
+	    <bgp-actions
+		xmlns="urn:ietf:params:xml:ns:yang:ietf-bgp-policy">
+	      <set-community>
+		<method>inline</method>
+		<inline>
+		  <communities>11:11</communities>
+		</inline>
+	      </set-community>
+	    </bgp-actions>
 	  </actions>
 	</statement>
       </statements>
     </policy-definition>
   </policy-definitions>
 </routing-policy>
+
+<routing
+    xmlns="urn:ietf:params:xml:ns:yang:ietf-routing"
+    xmlns:bt="urn:ietf:params:xml:ns:yang:ietf-bgp-types">
+  <control-plane-protocols>
+    <control-plane-protocol>
+      <type
+          xmlns:bgp="urn:ietf:params:xml:ns:yang:ietf-bgp">bgp:bgp</type>
+      <name>BGP</name>
+      <bgp
+          xmlns="urn:ietf:params:xml:ns:yang:ietf-bgp">
+        <global>
+          <as>1</as>
+          <afi-safis>
+            <afi-safi>
+              <name>bt:ipv4-unicast</name>
+            </afi-safi>
+          </afi-safis>
+        </global>
+	<neighbor>
+          <remote-address>10.1.1.2</remote-address>
+	  <peer-as>2</peer-as>
+          <afi-safis>
+            <afi-safi>
+              <name>bt:ipv4-unicast</name>
+	      <send-community>standard</send-community>
+	      <apply-policy>
+		<export-policy>TO_R2</export-policy>
+		<default-export-policy>accept-route</default-export-policy>
+	      </apply-policy>
+            </afi-safi>
+          </afi-safis>
+	  </neighbor>
+      </bgp>
+    </control-plane-protocol>
+  </control-plane-protocols>
+</routing>
+

--- a/src/yang/example-bgp-configuration-a.1.4.xml
+++ b/src/yang/example-bgp-configuration-a.1.4.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<routing-policy
+    xmlns="urn:ietf:params:xml:ns:yang:ietf-routing-policy">
+  <defined-sets>
+    <bgp-defined-sets>
+      <prefix-sets>
+	<prefix-set>
+	  <name>L0 and L1</name>
+	  <mode>ipv4-mode</mode>
+	  <prefixes>
+	    <prefix>
+	      <ip-prefix>1.1.1.1/32</ip-prefix>
+	      <masklength-range>exact</masklength-range>
+	    </prefix>
+	  </prefixes>
+	</prefix-set>
+      </prefix-sets>
+      <community-sets>
+	<community-set>
+	  <name>TO_R2</name>
+	  <member>What should this be?</member>
+	</community-set>
+      </community-sets>
+    </bgp-defined-sets>
+  </defined-sets>
+  <policy-definitions>
+    <policy-definition>
+      <name>TO_R2</name>
+      <statements>
+	<statement>
+	  <name>TO_R2</name>
+	  <actions>
+	    <set-community>
+	      <option>add</option>
+	      <community-set-ref>TO_R2</community-set-ref>
+	    </set-community>
+	  </actions>
+	</statement>
+      </statements>
+    </policy-definition>
+  </policy-definitions>
+</routing-policy>

--- a/src/yang/example-bgp-configuration-a.1.4.xml
+++ b/src/yang/example-bgp-configuration-a.1.4.xml
@@ -61,6 +61,7 @@
 	    <bgp-actions
 		xmlns="urn:ietf:params:xml:ns:yang:ietf-bgp-policy">
 	      <set-community>
+		<options>add</options>
 		<communities>11:11</communities>
 	      </set-community>
 	    </bgp-actions>
@@ -80,6 +81,7 @@
 	    <bgp-actions
 		xmlns="urn:ietf:params:xml:ns:yang:ietf-bgp-policy">
 	      <set-community>
+		<options>remove</options>
 		<communities>11:11</communities>
 		<communities>22:22</communities>
 	      </set-community>
@@ -100,6 +102,7 @@
 	    <bgp-actions
 		xmlns="urn:ietf:params:xml:ns:yang:ietf-bgp-policy">
 	      <set-community>
+		<options>replace</options>
 		<communities>33:33</communities>
 	      </set-community>
 	    </bgp-actions>

--- a/src/yang/example-bgp-configuration-a.1.4.xml
+++ b/src/yang/example-bgp-configuration-a.1.4.xml
@@ -7,7 +7,6 @@
       <prefix-sets>
 	<prefix-set>
 	  <name>L0andL1</name>
-	  <mode>ipv4-mode</mode>
 	  <prefixes>
 	    <prefix>
 	      <ip-prefix>1.1.1.1/32</ip-prefix>
@@ -21,7 +20,6 @@
 	</prefix-set>
 	<prefix-set>
 	  <name>L2andL3</name>
-	  <mode>ipv4-mode</mode>
 	  <prefixes>
 	    <prefix>
 	      <ip-prefix>3.3.3.3/32</ip-prefix>
@@ -34,8 +32,7 @@
 	  </prefixes>
 	</prefix-set>
 	<prefix-set>
-	  <name>L5</name>
-	  <mode>ipv4-mode</mode>
+	  <name>L4</name>
 	  <prefixes>
 	    <prefix>
 	      <ip-prefix>5.5.5.5/32</ip-prefix>
@@ -53,19 +50,18 @@
 	<statement>
 	  <name>10</name>
 	  <conditions>
-	    <match-prefix-set
+	    <bgp-conditions
 		xmlns="urn:ietf:params:xml:ns:yang:ietf-bgp-policy">
-	      <prefix-set>L0andL1</prefix-set>
-	    </match-prefix-set>
+	      <match-prefix-set>
+		<prefix-set>L0andL1</prefix-set>
+	      </match-prefix-set>
+	    </bgp-conditions>
 	  </conditions>
 	  <actions>
 	    <bgp-actions
 		xmlns="urn:ietf:params:xml:ns:yang:ietf-bgp-policy">
 	      <set-community>
-		<method>inline</method>
-		<inline>
-		  <communities>11:11</communities>
-		</inline>
+		<communities>11:11</communities>
 	      </set-community>
 	    </bgp-actions>
 	  </actions>
@@ -73,19 +69,19 @@
 	<statement>
 	  <name>20</name>
 	  <conditions>
-	    <match-prefix-set
+	    <bgp-conditions
 		xmlns="urn:ietf:params:xml:ns:yang:ietf-bgp-policy">
-	      <prefix-set>L2andL3</prefix-set>
-	    </match-prefix-set>
+	      <match-prefix-set>
+		<prefix-set>L2andL3</prefix-set>
+	      </match-prefix-set>
+	    </bgp-conditions>
 	  </conditions>
 	  <actions>
 	    <bgp-actions
 		xmlns="urn:ietf:params:xml:ns:yang:ietf-bgp-policy">
 	      <set-community>
-		<method>inline</method>
-		<inline>
-		  <communities>11:11 22:22</communities>
-		</inline>
+		<communities>11:11</communities>
+		<communities>22:22</communities>
 	      </set-community>
 	    </bgp-actions>
 	  </actions>
@@ -93,19 +89,18 @@
 	<statement>
 	  <name>30</name>
 	  <conditions>
-	    <match-prefix-set
+	    <bgp-conditions
 		xmlns="urn:ietf:params:xml:ns:yang:ietf-bgp-policy">
-	      <prefix-set>L4</prefix-set>
-	    </match-prefix-set>
+	      <match-prefix-set>
+		<prefix-set>L4</prefix-set>
+	      </match-prefix-set>
+	    </bgp-conditions>
 	  </conditions>
 	  <actions>
 	    <bgp-actions
 		xmlns="urn:ietf:params:xml:ns:yang:ietf-bgp-policy">
 	      <set-community>
-		<method>inline</method>
-		<inline>
-		  <communities>33:33</communities>
-		</inline>
+		<communities>33:33</communities>
 	      </set-community>
 	    </bgp-actions>
 	  </actions>
@@ -133,20 +128,22 @@
             </afi-safi>
           </afi-safis>
         </global>
-	<neighbor>
-          <remote-address>10.1.1.2</remote-address>
-	  <peer-as>2</peer-as>
-          <afi-safis>
-            <afi-safi>
-              <name>bt:ipv4-unicast</name>
-	      <send-community>standard</send-community>
-	      <apply-policy>
-		<export-policy>TO_R2</export-policy>
-		<default-export-policy>accept-route</default-export-policy>
-	      </apply-policy>
-            </afi-safi>
-          </afi-safis>
+	<neighbors>
+	  <neighbor>
+            <remote-address>10.1.1.2</remote-address>
+	    <peer-as>2</peer-as>
+            <afi-safis>
+              <afi-safi>
+		<name>bt:ipv4-unicast</name>
+	      </afi-safi>
+            </afi-safis>
+	    <send-community>bt:standard</send-community>
+	    <apply-policy>
+	      <export-policy>TO_R2</export-policy>
+	      <default-export-policy>accept-route</default-export-policy>
+	    </apply-policy>
 	  </neighbor>
+	</neighbors>
       </bgp>
     </control-plane-protocol>
   </control-plane-protocols>

--- a/src/yang/example-bgp-configuration-a.1.4.xml
+++ b/src/yang/example-bgp-configuration-a.1.4.xml
@@ -3,43 +3,43 @@
     xmlns="urn:ietf:params:xml:ns:yang:ietf-routing-policy">
   <defined-sets>
     <bgp-defined-sets
-	xmlns="urn:ietf:params:xml:ns:yang:ietf-bgp-policy">
+        xmlns="urn:ietf:params:xml:ns:yang:ietf-bgp-policy">
       <prefix-sets>
-	<prefix-set>
-	  <name>L0andL1</name>
-	  <prefixes>
-	    <prefix>
-	      <ip-prefix>1.1.1.1/32</ip-prefix>
-	      <masklength-range>exact</masklength-range>
-	    </prefix>
-	    <prefix>
-	      <ip-prefix>2.2.2.2/32</ip-prefix>
-	      <masklength-range>exact</masklength-range>
-	    </prefix>
-	  </prefixes>
-	</prefix-set>
-	<prefix-set>
-	  <name>L2andL3</name>
-	  <prefixes>
-	    <prefix>
-	      <ip-prefix>3.3.3.3/32</ip-prefix>
-	      <masklength-range>exact</masklength-range>
-	    </prefix>
-	    <prefix>
-	      <ip-prefix>4.4.4.4/32</ip-prefix>
-	      <masklength-range>exact</masklength-range>
-	    </prefix>
-	  </prefixes>
-	</prefix-set>
-	<prefix-set>
-	  <name>L4</name>
-	  <prefixes>
-	    <prefix>
-	      <ip-prefix>5.5.5.5/32</ip-prefix>
-	      <masklength-range>exact</masklength-range>
-	    </prefix>
-	  </prefixes>
-	</prefix-set>
+        <prefix-set>
+          <name>L0andL1</name>
+          <prefixes>
+            <prefix>
+              <ip-prefix>1.1.1.1/32</ip-prefix>
+              <masklength-range>exact</masklength-range>
+            </prefix>
+            <prefix>
+              <ip-prefix>2.2.2.2/32</ip-prefix>
+              <masklength-range>exact</masklength-range>
+            </prefix>
+          </prefixes>
+        </prefix-set>
+        <prefix-set>
+          <name>L2andL3</name>
+          <prefixes>
+            <prefix>
+              <ip-prefix>3.3.3.3/32</ip-prefix>
+              <masklength-range>exact</masklength-range>
+            </prefix>
+            <prefix>
+              <ip-prefix>4.4.4.4/32</ip-prefix>
+              <masklength-range>exact</masklength-range>
+            </prefix>
+          </prefixes>
+        </prefix-set>
+        <prefix-set>
+          <name>L4</name>
+          <prefixes>
+            <prefix>
+              <ip-prefix>5.5.5.5/32</ip-prefix>
+              <masklength-range>exact</masklength-range>
+            </prefix>
+          </prefixes>
+        </prefix-set>
       </prefix-sets>
     </bgp-defined-sets>
   </defined-sets>
@@ -47,67 +47,67 @@
     <policy-definition>
       <name>TO_R2</name>
       <statements>
-	<statement>
-	  <name>10</name>
-	  <conditions>
-	    <bgp-conditions
-		xmlns="urn:ietf:params:xml:ns:yang:ietf-bgp-policy">
-	      <match-prefix-set>
-		<prefix-set>L0andL1</prefix-set>
-	      </match-prefix-set>
-	    </bgp-conditions>
-	  </conditions>
-	  <actions>
-	    <bgp-actions
-		xmlns="urn:ietf:params:xml:ns:yang:ietf-bgp-policy">
-	      <set-community>
-		<options>add</options>
-		<communities>11:11</communities>
-	      </set-community>
-	    </bgp-actions>
-	  </actions>
-	</statement>
-	<statement>
-	  <name>20</name>
-	  <conditions>
-	    <bgp-conditions
-		xmlns="urn:ietf:params:xml:ns:yang:ietf-bgp-policy">
-	      <match-prefix-set>
-		<prefix-set>L2andL3</prefix-set>
-	      </match-prefix-set>
-	    </bgp-conditions>
-	  </conditions>
-	  <actions>
-	    <bgp-actions
-		xmlns="urn:ietf:params:xml:ns:yang:ietf-bgp-policy">
-	      <set-community>
-		<options>remove</options>
-		<communities>11:11</communities>
-		<communities>22:22</communities>
-	      </set-community>
-	    </bgp-actions>
-	  </actions>
-	</statement>
-	<statement>
-	  <name>30</name>
-	  <conditions>
-	    <bgp-conditions
-		xmlns="urn:ietf:params:xml:ns:yang:ietf-bgp-policy">
-	      <match-prefix-set>
-		<prefix-set>L4</prefix-set>
-	      </match-prefix-set>
-	    </bgp-conditions>
-	  </conditions>
-	  <actions>
-	    <bgp-actions
-		xmlns="urn:ietf:params:xml:ns:yang:ietf-bgp-policy">
-	      <set-community>
-		<options>replace</options>
-		<communities>33:33</communities>
-	      </set-community>
-	    </bgp-actions>
-	  </actions>
-	</statement>
+        <statement>
+          <name>10</name>
+          <conditions>
+            <bgp-conditions
+                xmlns="urn:ietf:params:xml:ns:yang:ietf-bgp-policy">
+              <match-prefix-set>
+                <prefix-set>L0andL1</prefix-set>
+              </match-prefix-set>
+            </bgp-conditions>
+          </conditions>
+          <actions>
+            <bgp-actions
+                xmlns="urn:ietf:params:xml:ns:yang:ietf-bgp-policy">
+              <set-community>
+                <options>add</options>
+                <communities>11:11</communities>
+              </set-community>
+            </bgp-actions>
+          </actions>
+        </statement>
+        <statement>
+          <name>20</name>
+          <conditions>
+            <bgp-conditions
+                xmlns="urn:ietf:params:xml:ns:yang:ietf-bgp-policy">
+              <match-prefix-set>
+                <prefix-set>L2andL3</prefix-set>
+              </match-prefix-set>
+            </bgp-conditions>
+          </conditions>
+          <actions>
+            <bgp-actions
+                xmlns="urn:ietf:params:xml:ns:yang:ietf-bgp-policy">
+              <set-community>
+                <options>remove</options>
+                <communities>11:11</communities>
+                <communities>22:22</communities>
+              </set-community>
+            </bgp-actions>
+          </actions>
+        </statement>
+        <statement>
+          <name>30</name>
+          <conditions>
+            <bgp-conditions
+                xmlns="urn:ietf:params:xml:ns:yang:ietf-bgp-policy">
+              <match-prefix-set>
+                <prefix-set>L4</prefix-set>
+              </match-prefix-set>
+            </bgp-conditions>
+          </conditions>
+          <actions>
+            <bgp-actions
+                xmlns="urn:ietf:params:xml:ns:yang:ietf-bgp-policy">
+              <set-community>
+                <options>replace</options>
+                <communities>33:33</communities>
+              </set-community>
+            </bgp-actions>
+          </actions>
+        </statement>
       </statements>
     </policy-definition>
   </policy-definitions>
@@ -131,24 +131,23 @@
             </afi-safi>
           </afi-safis>
         </global>
-	<neighbors>
-	  <neighbor>
+        <neighbors>
+          <neighbor>
             <remote-address>10.1.1.2</remote-address>
-	    <peer-as>2</peer-as>
+            <peer-as>2</peer-as>
             <afi-safis>
               <afi-safi>
-		<name>bt:ipv4-unicast</name>
-	      </afi-safi>
+                <name>bt:ipv4-unicast</name>
+              </afi-safi>
             </afi-safis>
-	    <send-community>bt:standard</send-community>
-	    <apply-policy>
-	      <export-policy>TO_R2</export-policy>
-	      <default-export-policy>accept-route</default-export-policy>
-	    </apply-policy>
-	  </neighbor>
-	</neighbors>
+            <send-community>bt:standard</send-community>
+            <apply-policy>
+              <export-policy>TO_R2</export-policy>
+              <default-export-policy>accept-route</default-export-policy>
+            </apply-policy>
+          </neighbor>
+        </neighbors>
       </bgp>
     </control-plane-protocol>
   </control-plane-protocols>
 </routing>
-

--- a/src/yang/ietf-bgp-policy.yang
+++ b/src/yang/ietf-bgp-policy.yang
@@ -333,58 +333,58 @@ module ietf-bgp-policy {
                supported on devices that require prefix sets to be
                of only one address family.";
           }
-        }
 
-        container prefixes {
-          description
-            "Enclosing container for the list of prefixes in a policy
-             prefix list.";
-
-          list prefix {
-            key "ip-prefix masklength-range";
+          container prefixes {
             description
-              "List of prefixes in the prefix set.";
+              "Enclosing container for the list of prefixes in a
+               policy prefix list.";
 
-            leaf ip-prefix {
-              type inet:ip-prefix;
-              mandatory true;
+            list prefix {
+              key "ip-prefix masklength-range";
               description
-                "The prefix member in CIDR notation. While the
-                 prefix may be either IPv4 or IPv6, most
-                 implementations require all members of the prefix
-                 set to be the same address family. Mixing address
-                 types in the same prefix set is likely to cause an
-                 error.";
-            }
+                "List of prefixes in the prefix set.";
 
-            leaf masklength-range {
-              type string {
-                pattern
-                  '(([0-9]+\.\.[0-9]+)|exact|le|ge)';
+              leaf ip-prefix {
+                type inet:ip-prefix;
+                mandatory true;
+                description
+                  "The prefix member in CIDR notation. While the
+                   prefix may be either IPv4 or IPv6, most
+                   implementations require all members of the prefix
+                   set to be the same address family. Mixing address
+                   types in the same prefix set is likely to cause an
+                   error.";
               }
-              description
-                "Defines a range for the masklength, 'exact' if
-                 the prefix has an exact length, 'le' if the
-                 masklength is <=, and 'ge' if >=. Note, the first
-                 number in the range has to be less than or equal to
-                 the second number and the first number must be
-                 greater than or equal to the prefix length.
 
-                 Example: 10.3.192.0/21 through 10.3.192.0/24 would
-                 be expressed as prefix: 10.3.192.0/21,
-                 masklength-range: 21..24.
+              leaf masklength-range {
+                type string {
+                  pattern
+                    '(([0-9]+\.\.[0-9]+)|exact|le|ge)';
+                }
+                description
+                  "Defines a range for the masklength, 'exact' if
+                   the prefix has an exact length, 'le' if the
+                   masklength is <=, and 'ge' if >=. Note, the first
+                   number in the range has to be less than or equal
+                   to the second number and the first number must be
+                   greater than or equal to the prefix length.
 
-                 Example: 10.3.192.0/21 would be expressed as
-                 prefix: 10.3.192.0/21,
-                 masklength-range: exact
+                   Example: 10.3.192.0/21 through 10.3.192.0/24 would
+                   be expressed as prefix: 10.3.192.0/21,
+                   masklength-range: 21..24.
 
-                 Example: 10.3.192.0/0 le 32 would be expressed as
-                 prefix: 10.3.192.0/32,
-                 masklength-range: le
+                   Example: 10.3.192.0/21 would be expressed as
+                   prefix: 10.3.192.0/21,
+                   masklength-range: exact
 
-                 Example: 10.3.192.0/0 ge 24 would be expressed as
-                 prefix: 10.3.192.0/24
-                 masklength-range: ge";
+                   Example: 10.3.192.0/0 le 32 would be expressed as
+                   prefix: 10.3.192.0/32,
+                   masklength-range: le
+
+                   Example: 10.3.192.0/0 ge 24 would be expressed as
+                   prefix: 10.3.192.0/24
+                   masklength-range: ge";
+              }
             }
           }
         }


### PR DESCRIPTION
This is my attempt to add a example on how to configure a policy using the BGP policy model.

The specific example that I am trying to follow is documented at:

https://community.cisco.com/t5/networking-documents/bgp-match-community-quot-statement-used-in-route-map/ta-p/3149898

I have several questions on this example. 

- How is the policy attached? Is it through the apply-policy->import-policy or apply-policy->export-policy?
- Is a (bgp)-defined-set the same as a route-map?
- How is prefix-mode decided?
- What should the masklength-range be in this case?
- route-map includes a 'set community' command? But 'set-community' under 'actions' has a 'community-set-ref' which points back to 'community-set'. Does it mean that I should be defining 11:11 as a community-set?
- What would be a good 'name' under policy-definition?
- What would be a good 'name under 'statement'?