### PR TITLE
Fix prefix set definition and the corresponding match

### DIFF
--- a/src/yang/example-bgp-configuration-a.1.4.xml
+++ b/src/yang/example-bgp-configuration-a.1.4.xml
@@ -2,46 +2,51 @@
 <routing-policy
     xmlns="urn:ietf:params:xml:ns:yang:ietf-routing-policy">
   <defined-sets>
-    <bgp-defined-sets
-        xmlns="urn:ietf:params:xml:ns:yang:ietf-bgp-policy">
-      <prefix-sets>
-        <prefix-set>
-          <name>L0andL1</name>
-          <prefixes>
-            <prefix>
-              <ip-prefix>1.1.1.1/32</ip-prefix>
-              <masklength-range>exact</masklength-range>
-            </prefix>
-            <prefix>
-              <ip-prefix>2.2.2.2/32</ip-prefix>
-              <masklength-range>exact</masklength-range>
-            </prefix>
-          </prefixes>
-        </prefix-set>
-        <prefix-set>
-          <name>L2andL3</name>
-          <prefixes>
-            <prefix>
-              <ip-prefix>3.3.3.3/32</ip-prefix>
-              <masklength-range>exact</masklength-range>
-            </prefix>
-            <prefix>
-              <ip-prefix>4.4.4.4/32</ip-prefix>
-              <masklength-range>exact</masklength-range>
-            </prefix>
-          </prefixes>
-        </prefix-set>
-        <prefix-set>
-          <name>L4</name>
-          <prefixes>
-            <prefix>
-              <ip-prefix>5.5.5.5/32</ip-prefix>
-              <masklength-range>exact</masklength-range>
-            </prefix>
-          </prefixes>
-        </prefix-set>
-      </prefix-sets>
-    </bgp-defined-sets>
+    <prefix-sets>
+      <prefix-set>
+        <name>L0andL1</name>
+	<mode>ipv4</mode>
+        <prefixes>
+          <prefix-list>
+            <ip-prefix>1.1.1.1/32</ip-prefix>
+	    <mask-length-lower>32</mask-length-lower>
+	    <mask-length-upper>32</mask-length-upper>
+          </prefix-list>
+          <prefix-list>
+            <ip-prefix>2.2.2.2/32</ip-prefix>
+	    <mask-length-lower>32</mask-length-lower>
+	    <mask-length-upper>32</mask-length-upper>
+          </prefix-list>
+        </prefixes>
+      </prefix-set>
+      <prefix-set>
+        <name>L2andL3</name>
+	<mode>ipv4</mode>
+        <prefixes>
+          <prefix-list>
+            <ip-prefix>3.3.3.3/32</ip-prefix>
+	    <mask-length-lower>32</mask-length-lower>
+	    <mask-length-upper>32</mask-length-upper>
+          </prefix-list>
+          <prefix-list>
+            <ip-prefix>4.4.4.4/32</ip-prefix>
+	    <mask-length-lower>32</mask-length-lower>
+	    <mask-length-upper>32</mask-length-upper>
+          </prefix-list>
+        </prefixes>
+      </prefix-set>
+      <prefix-set>
+        <name>L4</name>
+	<mode>ipv4</mode>
+        <prefixes>
+          <prefix-list>
+            <ip-prefix>5.5.5.5/32</ip-prefix>
+	    <mask-length-lower>32</mask-length-lower>
+	    <mask-length-upper>32</mask-length-upper>
+          </prefix-list>
+        </prefixes>
+      </prefix-set>
+    </prefix-sets>
   </defined-sets>
   <policy-definitions>
     <policy-definition>
@@ -50,12 +55,9 @@
         <statement>
           <name>10</name>
           <conditions>
-            <bgp-conditions
-                xmlns="urn:ietf:params:xml:ns:yang:ietf-bgp-policy">
-              <match-prefix-set>
-                <prefix-set>L0andL1</prefix-set>
-              </match-prefix-set>
-            </bgp-conditions>
+            <match-prefix-set>
+              <prefix-set>L0andL1</prefix-set>
+            </match-prefix-set>
           </conditions>
           <actions>
             <bgp-actions
@@ -70,12 +72,9 @@
         <statement>
           <name>20</name>
           <conditions>
-            <bgp-conditions
-                xmlns="urn:ietf:params:xml:ns:yang:ietf-bgp-policy">
-              <match-prefix-set>
-                <prefix-set>L2andL3</prefix-set>
-              </match-prefix-set>
-            </bgp-conditions>
+            <match-prefix-set>
+              <prefix-set>L2andL3</prefix-set>
+            </match-prefix-set>
           </conditions>
           <actions>
             <bgp-actions
@@ -91,12 +90,9 @@
         <statement>
           <name>30</name>
           <conditions>
-            <bgp-conditions
-                xmlns="urn:ietf:params:xml:ns:yang:ietf-bgp-policy">
-              <match-prefix-set>
-                <prefix-set>L4</prefix-set>
-              </match-prefix-set>
-            </bgp-conditions>
+            <match-prefix-set>
+              <prefix-set>L4</prefix-set>
+            </match-prefix-set>
           </conditions>
           <actions>
             <bgp-actions

--- a/src/yang/example-bgp-configuration-a.1.4.xml
+++ b/src/yang/example-bgp-configuration-a.1.4.xml
@@ -2,9 +2,8 @@
 <routing-policy
     xmlns="urn:ietf:params:xml:ns:yang:ietf-routing-policy">
   <defined-sets>
-    <bgp-defined-sets
+    <prefix-sets
         xmlns="urn:ietf:params:xml:ns:yang:ietf-bgp-policy">
-      <prefix-sets>
         <prefix-set>
           <name>L0andL1</name>
           <prefixes>
@@ -41,7 +40,6 @@
           </prefixes>
         </prefix-set>
       </prefix-sets>
-    </bgp-defined-sets>
   </defined-sets>
   <policy-definitions>
     <policy-definition>

--- a/src/yang/example-bgp-configuration-a.1.4.xml
+++ b/src/yang/example-bgp-configuration-a.1.4.xml
@@ -2,8 +2,9 @@
 <routing-policy
     xmlns="urn:ietf:params:xml:ns:yang:ietf-routing-policy">
   <defined-sets>
-    <prefix-sets
+    <bgp-defined-sets
         xmlns="urn:ietf:params:xml:ns:yang:ietf-bgp-policy">
+      <prefix-sets>
         <prefix-set>
           <name>L0andL1</name>
           <prefixes>
@@ -40,6 +41,7 @@
           </prefixes>
         </prefix-set>
       </prefix-sets>
+    </bgp-defined-sets>
   </defined-sets>
   <policy-definitions>
     <policy-definition>

--- a/src/yang/ietf-bgp-policy.yang
+++ b/src/yang/ietf-bgp-policy.yang
@@ -277,83 +277,6 @@ module ietf-bgp-policy {
           }
         }
       }
-    
-      container prefix-sets {
-        description
-          "Definitions for a list of IPv4 or IPv6 prefixes which
-           are matched as part of a policy.";
-
-        list prefix-set {
-          key "name";
-          description
-            "List of the defined prefix sets";
-
-          leaf name {
-            type string;
-            description
-              "Name of the prefix set used to reference the set in
-               match conditions.";
-          }
-
-          container prefixes {
-            description
-              "Enclosing container for the list of prefixes in a
-               policy prefix list.";
-
-            list prefix {
-              key "ip-prefix masklength-range";
-              description
-                "List of prefixes in the prefix set.";
-
-              leaf ip-prefix {
-                type inet:ip-prefix;
-                mandatory true;
-                description
-                  "The prefix member in CIDR notation. While the
-                   prefix may be either IPv4 or IPv6, most
-                   implementations require all members of the prefix
-                   set to be the same address family. Mixing address
-                   types in the same prefix set is likely to cause an
-                   error.";
-              }
-
-              leaf masklength-range {
-                type string {
-                  pattern
-                    '(([0-9]+\.\.[0-9]+)|exact|le|ge)';
-                }
-                description
-                  "Defines a range for the masklength, 'exact' if
-                   the prefix has an exact length, 'le' if the
-                   masklength is <=, and 'ge' if >=. Note, the first
-                   number in the range has to be less than or equal to
-                   the second number and the first number must be
-                   greater than or equal to the prefix length. Also,
-                   if this is a IPv4 prefix, the masklength should not
-                   be greater than 32, and if this is a IPv6 prefix,
-                   the masklength should not be greater than 127.
-
-                   Example: 10.3.192.0/21 through 10.3.192.0/24 would
-                   be expressed as 
-                   prefix: 10.3.192.0/21,
-                   masklength-range: 21..24.
-
-                   Example: 10.3.192.0/21 would be expressed as
-                   prefix: 10.3.192.0/21,
-                   masklength-range: exact
-
-                   Example: 10.3.192.0/0 le 32 would be expressed as
-                   prefix: 10.3.192.0/32,
-                   masklength-range: le
-
-                   Example: 10.3.192.0/0 ge 24 would be expressed as
-                   prefix: 10.3.192.0/24
-                   masklength-range: ge";
-              }
-            }
-          }
-        }
-      }
     }
   }
 
@@ -592,21 +515,6 @@ module ietf-bgp-policy {
             "Reference a defined next-hop set.";
         }
         uses rt-pol:match-set-options-group;
-      }
-
-      container match-prefix-set {
-        description
-          "Match a referenced prefix-set according to the logic
-           defined in the match-set-options leaf.";
-
-        leaf prefix-set {
-          type leafref {
-            path "/rt-pol:routing-policy/rt-pol:defined-sets" +
-                 "/bgp-defined-sets/prefix-sets/prefix-set/name";
-          }
-          description "References a defined prefix set.";
-        }
-        uses rt-pol:match-set-options-restricted-group;
       }
     }
   }

--- a/src/yang/ietf-bgp-policy.yang
+++ b/src/yang/ietf-bgp-policy.yang
@@ -295,17 +295,16 @@ module ietf-bgp-policy {
             "Name of the prefix set used to reference the set in
              match conditions.";
         }
-      }
 
-      container prefixes {
-        description
-          "Enclosing container for the list of prefixes in a policy
-           prefix list.";
-
-        list prefix {
-          key "ip-prefix masklength-range";
+        container prefixes {
           description
-            "List of prefixes in the prefix set.";
+            "Enclosing container for the list of prefixes in a policy
+             prefix list.";
+
+          list prefix {
+            key "ip-prefix masklength-range";
+            description
+              "List of prefixes in the prefix set.";
 
           leaf ip-prefix {
             type inet:ip-prefix;
@@ -351,6 +350,7 @@ module ietf-bgp-policy {
                Example: 10.3.192.0/0 ge 24 would be expressed as
                prefix: 10.3.192.0/24
                masklength-range: ge";
+            }
           }
         }
       }
@@ -593,20 +593,21 @@ module ietf-bgp-policy {
         }
         uses rt-pol:match-set-options-group;
       }
-    }
-    container match-prefix-set {
-      description
-        "Match a referenced prefix-set according to the logic
-         defined in the match-set-options leaf.";
 
-      leaf prefix-set {
-        type leafref {
-          path "/rt-pol:routing-policy/rt-pol:defined-sets/" +
-               "prefix-sets/prefix-set/name";
+      container match-prefix-set {
+        description
+          "Match a referenced prefix-set according to the logic
+           defined in the match-set-options leaf.";
+
+        leaf prefix-set {
+          type leafref {
+            path "/rt-pol:routing-policy/rt-pol:defined-sets/" +
+                 "prefix-sets/prefix-set/name";
+          }
+          description "References a defined prefix set.";
         }
-        description "References a defined prefix set.";
+        uses rt-pol:match-set-options-restricted-group;
       }
-      uses rt-pol:match-set-options-restricted-group;
     }
   }
 

--- a/src/yang/ietf-bgp-policy.yang
+++ b/src/yang/ietf-bgp-policy.yang
@@ -277,79 +277,79 @@ module ietf-bgp-policy {
           }
         }
       }
-    }
-
-    container prefix-sets {
-      description
-        "Definitions for a list of IPv4 or IPv6 prefixes which
-         are matched as part of a policy.";
-
-      list prefix-set {
-        key "name";
+    
+      container prefix-sets {
         description
-          "List of the defined prefix sets";
+          "Definitions for a list of IPv4 or IPv6 prefixes which
+           are matched as part of a policy.";
 
-        leaf name {
-          type string;
+        list prefix-set {
+          key "name";
           description
-            "Name of the prefix set used to reference the set in
-             match conditions.";
-        }
+            "List of the defined prefix sets";
 
-        container prefixes {
-          description
-            "Enclosing container for the list of prefixes in a policy
-             prefix list.";
-
-          list prefix {
-            key "ip-prefix masklength-range";
+          leaf name {
+            type string;
             description
-              "List of prefixes in the prefix set.";
-
-          leaf ip-prefix {
-            type inet:ip-prefix;
-            mandatory true;
-            description
-              "The prefix member in CIDR notation. While the
-               prefix may be either IPv4 or IPv6, most
-               implementations require all members of the prefix
-               set to be the same address family. Mixing address
-               types in the same prefix set is likely to cause an
-               error.";
+              "Name of the prefix set used to reference the set in
+               match conditions.";
           }
 
-          leaf masklength-range {
-            type string {
-              pattern
-                '(([0-9]+\.\.[0-9]+)|exact|le|ge)';
-            }
+          container prefixes {
             description
-              "Defines a range for the masklength, 'exact' if
-               the prefix has an exact length, 'le' if the
-               masklength is <=, and 'ge' if >=. Note, the first
-               number in the range has to be less than or equal to
-               the second number and the first number must be
-               greater than or equal to the prefix length. Also,
-               if this is a IPv4 prefix, the masklength should not
-               be greater than 32, and if this is a IPv6 prefix,
-               the masklength should not be greater than 127.
+              "Enclosing container for the list of prefixes in a
+               policy prefix list.";
 
-               Example: 10.3.192.0/21 through 10.3.192.0/24 would
-               be expressed as 
-               prefix: 10.3.192.0/21,
-               masklength-range: 21..24.
+            list prefix {
+              key "ip-prefix masklength-range";
+              description
+                "List of prefixes in the prefix set.";
 
-               Example: 10.3.192.0/21 would be expressed as
-               prefix: 10.3.192.0/21,
-               masklength-range: exact
+              leaf ip-prefix {
+                type inet:ip-prefix;
+                mandatory true;
+                description
+                  "The prefix member in CIDR notation. While the
+                   prefix may be either IPv4 or IPv6, most
+                   implementations require all members of the prefix
+                   set to be the same address family. Mixing address
+                   types in the same prefix set is likely to cause an
+                   error.";
+              }
 
-               Example: 10.3.192.0/0 le 32 would be expressed as
-               prefix: 10.3.192.0/32,
-               masklength-range: le
+              leaf masklength-range {
+                type string {
+                  pattern
+                    '(([0-9]+\.\.[0-9]+)|exact|le|ge)';
+                }
+                description
+                  "Defines a range for the masklength, 'exact' if
+                   the prefix has an exact length, 'le' if the
+                   masklength is <=, and 'ge' if >=. Note, the first
+                   number in the range has to be less than or equal to
+                   the second number and the first number must be
+                   greater than or equal to the prefix length. Also,
+                   if this is a IPv4 prefix, the masklength should not
+                   be greater than 32, and if this is a IPv6 prefix,
+                   the masklength should not be greater than 127.
 
-               Example: 10.3.192.0/0 ge 24 would be expressed as
-               prefix: 10.3.192.0/24
-               masklength-range: ge";
+                   Example: 10.3.192.0/21 through 10.3.192.0/24 would
+                   be expressed as 
+                   prefix: 10.3.192.0/21,
+                   masklength-range: 21..24.
+
+                   Example: 10.3.192.0/21 would be expressed as
+                   prefix: 10.3.192.0/21,
+                   masklength-range: exact
+
+                   Example: 10.3.192.0/0 le 32 would be expressed as
+                   prefix: 10.3.192.0/32,
+                   masklength-range: le
+
+                   Example: 10.3.192.0/0 ge 24 would be expressed as
+                   prefix: 10.3.192.0/24
+                   masklength-range: ge";
+              }
             }
           }
         }
@@ -601,8 +601,8 @@ module ietf-bgp-policy {
 
         leaf prefix-set {
           type leafref {
-            path "/rt-pol:routing-policy/rt-pol:defined-sets/" +
-                 "prefix-sets/prefix-set/name";
+            path "/rt-pol:routing-policy/rt-pol:defined-sets" +
+                 "/bgp-defined-sets/prefix-sets/prefix-set/name";
           }
           description "References a defined prefix set.";
         }


### PR DESCRIPTION
As currently defined, prefix-sets are not a child of bgp-defined-sets, and prefixes are not a child of list prefix-set. 

The former I believe should be a child, unless we believe that the prefix-sets can be used outside of bgp(-defined-sets). The latter I believe leads to a prefix-set definition that contains no prefixes.

But since these code was reviewed before, and these changes are coming at the last minute, I want us to be careful reviewing this change before accepting it.