### PR TITLE
How to maintain extended-community datatype

### DIFF
--- a/draft/Makefile
+++ b/draft/Makefile
@@ -49,14 +49,14 @@ endif
 	-rm -f ../bin/submodules/*\@$(shell date +%Y)*.yang
 	-rm -f ../bin/submodules/*\@$(shell date +%Y)*-*-*.yang
 
-$(next).xml: $(draft).xml ../src/yang/ietf-bgp-common-multiprotocol.yang ../src/yang/ietf-bgp-common-structure.yang ../src/yang/ietf-bgp-common.yang ../src/yang/ietf-bgp-neighbor.yang ../src/yang/ietf-bgp-policy.yang ../src/yang/ietf-bgp-types.yang ../src/yang/ietf-bgp.yang rib
+$(next).xml: $(draft).xml ../src/yang/ietf-bgp-common-multiprotocol.yang ../src/yang/ietf-bgp-common-structure.yang ../src/yang/ietf-bgp-common.yang ../src/yang/ietf-bgp-neighbor.yang ../src/yang/ietf-bgp-policy.yang ../src/yang/iana-bgp-types.yang ../src/yang/ietf-bgp.yang rib
 	sed -e"s/$(basename $<)-latest/$(basename $@)/" -e"s/YYYY-MM-DD/$(shell date +%Y-%m-%d)/" $< > $@
 	sed -e"s/YYYY-MM-DD/$(shell date +%Y-%m-%d)/" ../src/yang/ietf-bgp-common-multiprotocol.yang > ../bin/submodules/ietf-bgp-common-multiprotocol\@$(shell date +%Y-%m-%d).yang
 	sed -e"s/YYYY-MM-DD/$(shell date +%Y-%m-%d)/" ../src/yang/ietf-bgp-common-structure.yang > ../bin/submodules/ietf-bgp-common-structure\@$(shell date +%Y-%m-%d).yang
 	sed -e"s/YYYY-MM-DD/$(shell date +%Y-%m-%d)/" ../src/yang/ietf-bgp-common.yang > ../bin/submodules/ietf-bgp-common\@$(shell date +%Y-%m-%d).yang
 	sed -e"s/YYYY-MM-DD/$(shell date +%Y-%m-%d)/" ../src/yang/ietf-bgp-neighbor.yang > ../bin/submodules/ietf-bgp-neighbor\@$(shell date +%Y-%m-%d).yang
 	sed -e"s/YYYY-MM-DD/$(shell date +%Y-%m-%d)/" ../src/yang/ietf-bgp-policy.yang > ../bin/ietf-bgp-policy\@$(shell date +%Y-%m-%d).yang
-	sed -e"s/YYYY-MM-DD/$(shell date +%Y-%m-%d)/" ../src/yang/ietf-bgp-types.yang > ../bin/ietf-bgp-types\@$(shell date +%Y-%m-%d).yang
+	sed -e"s/YYYY-MM-DD/$(shell date +%Y-%m-%d)/" ../src/yang/iana-bgp-types.yang > ../bin/iana-bgp-types\@$(shell date +%Y-%m-%d).yang
 	sed -e"s/YYYY-MM-DD/$(shell date +%Y-%m-%d)/" ../src/yang/ietf-bgp.yang > ../bin/ietf-bgp\@$(shell date +%Y-%m-%d).yang
 	sed -e"s/YYYY-MM-DD/$(shell date +%Y-%m-%d)/" ../src/yang/example-newafi-bgp.yang > ../bin/example-newafi-bgp\@$(shell date +%Y-%m-%d).yang
 	sed -e"s/YYYY-MM-DD/$(shell date +%Y-%m-%d)/" ../src/yang/example-newco-bgp-a.2.yang > ../bin/example-newco-bgp-a.2\@$(shell date +%Y-%m-%d).yang

--- a/draft/draft-ietf-idr-bgp-model.xml
+++ b/draft/draft-ietf-idr-bgp-model.xml
@@ -565,7 +565,7 @@ INSERT_TEXT_FROM_FILE(../bin/ietf-bgp@YYYY-MM-DD-rib-tree.txt)
         be made: <figure>
             <artwork><![CDATA[URI: urn:ietf:params:xml:ns:yang:ietf-bgp
 URI: urn:ietf:params:xml:ns:yang:ietf-bgp-policy
-URI: urn:ietf:params:xml:ns:yang:ietf-bgp-types
+URI: urn:ietf:params:xml:ns:yang:iana-bgp-types
 ]]></artwork>
           </figure></t>
 
@@ -588,8 +588,8 @@ namespace: urn:ietf:params:xml:ns:yang:ietf-bgp-policy
 prefix: bp
 reference: RFC XXXX
 
-name: ietf-bgp-types
-namespace: urn:ietf:params:xml:ns:yang:ietf-bgp-types
+name: iana-bgp-types
+namespace: urn:ietf:params:xml:ns:yang:iana-bgp-types
 prefix: bt
 reference: RFC XXXX
 ]]></artwork>
@@ -623,7 +623,7 @@ reference: RFC XXXX
         </list></t>
 
       <t>Additionally, modules include: <list style="symbols">
-          <t>ietf-bgp-types - common type and identity definitions for BGP,
+          <t>iana-bgp-types - common type and identity definitions for BGP,
           including BGP policy</t>
 
           <t>ietf-bgp-policy - BGP-specific policy data definitions for use
@@ -711,8 +711,8 @@ INSERT_TEXT_FROM_FILE(../bin/submodules/ietf-bgp-neighbor@YYYY-MM-DD.yang)
       <section title="BGP types">
         <t><figure>
             <artwork><![CDATA[
-<CODE BEGINS> file "ietf-bgp-types@YYYY-MM-DD.yang"
-INSERT_TEXT_FROM_FILE(../bin/ietf-bgp-types@YYYY-MM-DD.yang)
+<CODE BEGINS> file "iana-bgp-types@YYYY-MM-DD.yang"
+INSERT_TEXT_FROM_FILE(../bin/iana-bgp-types@YYYY-MM-DD.yang)
 <CODE ENDS>
 
         ]]></artwork>

--- a/src/validate-and-gen-trees.sh
+++ b/src/validate-and-gen-trees.sh
@@ -104,7 +104,7 @@ for i in yang/example-bgp-configuration-a.1.[0-3].xml
 do
     name=$(echo $i | cut -f 1-3 -d '.')
     echo "Validating $name.xml"
-    response=`yanglint -ii -t config -p ../../iana/yang-parameters -p ../bin -p ../bin/submodules ../../iana/yang-parameters/ietf-network-instance@2019-01-21.yang ../bin/ietf-bgp-types\@$(date +%Y-%m-%d).yang ../bin/ietf-bgp\@$(date +%Y-%m-%d).yang $name.xml`
+    response=`yanglint -ii -t config -p ../../iana/yang-parameters -p ../bin -p ../bin/submodules ../../iana/yang-parameters/ietf-network-instance@2019-01-21.yang ../bin/iana-bgp-types\@$(date +%Y-%m-%d).yang ../bin/ietf-bgp\@$(date +%Y-%m-%d).yang $name.xml`
     if [ $? -ne 0 ]; then
        printf "failed (error code: $?)\n"
        printf "$response\n\n"
@@ -118,7 +118,7 @@ for i in yang/example-bgp-configuration-a.1.4.xml
 do
     name=$(echo $i | cut -f 1-3 -d '.')
     echo "Validating $name.xml"
-    response=`yanglint -ii -t config -p ../../iana/yang-parameters -p ../bin -p ../bin/submodules ../../iana/yang-parameters/ietf-network-instance@2019-01-21.yang ../bin/ietf-bgp-types\@$(date +%Y-%m-%d).yang ../bin/ietf-bgp\@$(date +%Y-%m-%d).yang ../bin/ietf-bgp-policy\@$(date +%Y-%m-%d).yang $name.xml`
+    response=`yanglint -ii -t config -p ../../iana/yang-parameters -p ../bin -p ../bin/submodules ../../iana/yang-parameters/ietf-network-instance@2019-01-21.yang ../bin/iana-bgp-types\@$(date +%Y-%m-%d).yang ../bin/ietf-bgp\@$(date +%Y-%m-%d).yang ../bin/ietf-bgp-policy\@$(date +%Y-%m-%d).yang $name.xml`
     if [ $? -ne 0 ]; then
        printf "failed (error code: $?)\n"
        printf "$response\n\n"

--- a/src/yang/example-bgp-configuration-a.1.0.xml
+++ b/src/yang/example-bgp-configuration-a.1.0.xml
@@ -14,7 +14,7 @@
             <afi-safi>
               <name
                   xmlns:bt=
-                  "urn:ietf:params:xml:ns:yang:ietf-bgp-types">bt:ipv4-unicast</name>
+                  "urn:ietf:params:xml:ns:yang:iana-bgp-types">bt:ipv4-unicast</name>
             </afi-safi>
           </afi-safis>
         </global>

--- a/src/yang/example-bgp-configuration-a.1.1.xml
+++ b/src/yang/example-bgp-configuration-a.1.1.xml
@@ -5,7 +5,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <routing
     xmlns="urn:ietf:params:xml:ns:yang:ietf-routing"
-      xmlns:bt="urn:ietf:params:xml:ns:yang:ietf-bgp-types">
+      xmlns:bt="urn:ietf:params:xml:ns:yang:iana-bgp-types">
   <control-plane-protocols>
     <control-plane-protocol>
       <type

--- a/src/yang/example-bgp-configuration-a.1.2.xml
+++ b/src/yang/example-bgp-configuration-a.1.2.xml
@@ -20,7 +20,7 @@
             <afi-safi>
               <name
                   xmlns:bt=
-                  "urn:ietf:params:xml:ns:yang:ietf-bgp-types">bt:ipv6-unicast</name>
+                  "urn:ietf:params:xml:ns:yang:iana-bgp-types">bt:ipv6-unicast</name>
             </afi-safi>
           </afi-safis>
         </global>
@@ -43,7 +43,7 @@
               <afi-safi>
                 <name
                     xmlns:bt=
-                    "urn:ietf:params:xml:ns:yang:ietf-bgp-types">bt:ipv6-unicast</name>
+                    "urn:ietf:params:xml:ns:yang:iana-bgp-types">bt:ipv6-unicast</name>
               </afi-safi>
             </afi-safis>
           </neighbor>

--- a/src/yang/example-bgp-configuration-a.1.3.xml
+++ b/src/yang/example-bgp-configuration-a.1.3.xml
@@ -21,7 +21,7 @@
                   <afi-safi>
                     <name
                         xmlns:bt=
-                        "urn:ietf:params:xml:ns:yang:ietf-bgp-types">bt:ipv4-unicast</name>
+                        "urn:ietf:params:xml:ns:yang:iana-bgp-types">bt:ipv4-unicast</name>
                   </afi-safi>
                 </afi-safis>
               </global>
@@ -51,7 +51,7 @@
                   <afi-safi>
                     <name
                         xmlns:bt=
-                        "urn:ietf:params:xml:ns:yang:ietf-bgp-types">bt:ipv4-unicast</name>
+                        "urn:ietf:params:xml:ns:yang:iana-bgp-types">bt:ipv4-unicast</name>
                   </afi-safi>
                 </afi-safis>
               </global>

--- a/src/yang/example-bgp-configuration-a.1.4.xml
+++ b/src/yang/example-bgp-configuration-a.1.4.xml
@@ -111,7 +111,7 @@
 
 <routing
     xmlns="urn:ietf:params:xml:ns:yang:ietf-routing"
-    xmlns:bt="urn:ietf:params:xml:ns:yang:ietf-bgp-types">
+    xmlns:bt="urn:ietf:params:xml:ns:yang:iana-bgp-types">
   <control-plane-protocols>
     <control-plane-protocol>
       <type

--- a/src/yang/example-newafi-bgp.yang
+++ b/src/yang/example-newafi-bgp.yang
@@ -22,7 +22,7 @@ module example-newafi-bgp {
       "RFC XXXX: BGP YANG module for Service Provider Network.";
   }
 
-  import ietf-bgp-types {
+  import iana-bgp-types {
     prefix "bt";
   }
 

--- a/src/yang/iana-bgp-types.yang
+++ b/src/yang/iana-bgp-types.yang
@@ -514,7 +514,10 @@ module iana-bgp-types {
       }
     }
     description
-      "Type definition for extended community attributes";
+      "Type definition for extended community attributes.
+       It includes a way to specify a 'raw' string that
+       is followed by 8 bytes of octet string to support
+       new and experimental type definitions.";
     reference
       "RFC 4360 - BGP Extended Communities Attribute";
   }

--- a/src/yang/iana-bgp-types.yang
+++ b/src/yang/iana-bgp-types.yang
@@ -1,6 +1,6 @@
-module ietf-bgp-types {
+module iana-bgp-types {
   yang-version 1.1;
-  namespace "urn:ietf:params:xml:ns:yang:ietf-bgp-types";
+  namespace "urn:ietf:params:xml:ns:yang:iana-bgp-types";
   prefix bt;
 
   import ietf-inet-types {
@@ -10,10 +10,16 @@ module ietf-bgp-types {
   // meta
 
   organization
-    "IETF IDR Working Group";
+    "IANA";
   contact
-    "WG Web:   <http://tools.ietf.org/wg/idr>
-     WG List:  <idr@ietf.org>
+    "Internet Assigned Numbers Authority
+
+     Postal: ICANN
+             12025 Waterfront Drive, Suite 300
+             Los Angeles, CA 90094-2536
+             United States of America
+     Tel:    +1 310 301 5800
+     <mailto:iana@iana.org>
 
      Authors: Mahesh Jethanandani (mjethanandani at gmail.com),
               Keyur Patel (keyur at arrcus.com),
@@ -23,6 +29,10 @@ module ietf-bgp-types {
   description
     "This module contains general data definitions for use in BGP.
      It can be imported by modules that make use of BGP attributes.
+
+     This YANG module is maintained by IANA and reflects the
+     'BGP Identities for Community' and 'BGP definitions for
+     Community type' registries.
 
      Copyright (c) 2021 IETF Trust and the persons identified as
      authors of the code. All rights reserved.
@@ -496,6 +506,11 @@ module ietf-bgp-types {
               + '2[0-4][0-9]|25[0-5]):'
               + '(6[0-5][0-5][0-3][0-5]|[1-5][0-9]{4}|'
               + '[1-9][0-9]{1,4}|[0-9])';
+      }
+
+      type string {
+        // raw with 8 octetes
+        pattern 'raw:([0-9A-F][0-9A-F]:){7}[0-9A-F][0-9A-F]';
       }
     }
     description

--- a/src/yang/iana-bgp-types.yang
+++ b/src/yang/iana-bgp-types.yang
@@ -509,7 +509,7 @@ module iana-bgp-types {
       }
 
       type string {
-        // raw with 8 octetes
+        // raw with 8 octets
         pattern 'raw:([0-9A-F][0-9A-F]:){7}[0-9A-F][0-9A-F]';
       }
     }

--- a/src/yang/ietf-bgp-common-multiprotocol.yang
+++ b/src/yang/ietf-bgp-common-multiprotocol.yang
@@ -4,7 +4,7 @@ submodule ietf-bgp-common-multiprotocol {
     prefix bgp;
   }
 
-  import ietf-bgp-types {
+  import iana-bgp-types {
     prefix bt;
   }
   import ietf-routing-policy {

--- a/src/yang/ietf-bgp-common-structure.yang
+++ b/src/yang/ietf-bgp-common-structure.yang
@@ -9,7 +9,7 @@ submodule ietf-bgp-common-structure {
     reference
       "RFC ZZZZ, A YANG Data Model for Routing Policy Management";
   }
-  import ietf-bgp-types {
+  import iana-bgp-types {
     prefix bt;
     reference
       "RFC XXXX, BGP YANG Model for Service Provider Network.";

--- a/src/yang/ietf-bgp-common.yang
+++ b/src/yang/ietf-bgp-common.yang
@@ -4,7 +4,7 @@ submodule ietf-bgp-common {
     prefix bgp;
   }
 
-  import ietf-bgp-types {
+  import iana-bgp-types {
     prefix bt;
     reference
       "RFC XXXX: BGP Model for Service Provider Network.";

--- a/src/yang/ietf-bgp-neighbor.yang
+++ b/src/yang/ietf-bgp-neighbor.yang
@@ -10,7 +10,7 @@ submodule ietf-bgp-neighbor {
       "RFC 6991: Common YANG Data Types.";
   }
 
-  import ietf-bgp-types {
+  import iana-bgp-types {
     prefix bt;
     reference
       "RFC XXXX, BGP Model for Service Provider Network.";

--- a/src/yang/ietf-bgp-policy.yang
+++ b/src/yang/ietf-bgp-policy.yang
@@ -11,7 +11,7 @@ module ietf-bgp-policy {
   import ietf-routing-policy {
     prefix rt-pol;
   }
-  import ietf-bgp-types {
+  import iana-bgp-types {
     prefix bt;
   }
   import ietf-routing-types {

--- a/src/yang/ietf-bgp-rib-attributes.yang
+++ b/src/yang/ietf-bgp-rib-attributes.yang
@@ -226,7 +226,7 @@ submodule ietf-bgp-rib-attributes {
 
     leaf-list ext-community-raw {
       type string {
-        // raw with 8 octetes
+        // raw with 8 octets
         pattern 'raw:([0-9A-F][0-9A-F]:){7}[0-9A-F][0-9A-F]';
       }
       description

--- a/src/yang/ietf-bgp-rib-attributes.yang
+++ b/src/yang/ietf-bgp-rib-attributes.yang
@@ -6,7 +6,7 @@ submodule ietf-bgp-rib-attributes {
 
   // import some basic types
 
-  import ietf-bgp-types {
+  import iana-bgp-types {
     prefix bt;
   }
   import ietf-inet-types {
@@ -222,6 +222,15 @@ submodule ietf-bgp-rib-attributes {
          formatted according to RFC 4360.";
       reference
         "RFC 4360 - BGP Extended Communities Attribute";
+    }
+
+    leaf-list ext-community-raw {
+      type string {
+        // raw with 8 octetes
+        pattern 'raw:([0-9A-F][0-9A-F]:){7}[0-9A-F][0-9A-F]';
+      }
+      description
+        "ext-community type in raw format only.";
     }
   }
 

--- a/src/yang/ietf-bgp-rib-tables.yang
+++ b/src/yang/ietf-bgp-rib-tables.yang
@@ -21,7 +21,7 @@ submodule ietf-bgp-rib-tables {
     reference
       "RFC 8022: A YANG Data Model for Routing Management.";
   }
-  import ietf-bgp-types {
+  import iana-bgp-types {
     prefix bt;
     reference
       "RFC XXXX: BGP YANG Model for Service Provider Network.";

--- a/src/yang/ietf-bgp-rib.yang
+++ b/src/yang/ietf-bgp-rib.yang
@@ -8,7 +8,7 @@ submodule ietf-bgp-rib {
    * Import and Include
    */
 
-  import ietf-bgp-types {
+  import iana-bgp-types {
     prefix bt;
     reference
       "RFC XXXX: BGP YANG Model for Service Provider Networks.";

--- a/src/yang/ietf-bgp.yang
+++ b/src/yang/ietf-bgp.yang
@@ -23,7 +23,7 @@ module ietf-bgp {
     reference
       "RFC 8343, A YANG Data Model for Interface Management.";
   }
-  import ietf-bgp-types {
+  import iana-bgp-types {
     prefix bt;
     reference
       "RFC XXXX, BGP YANG Model for Service Provider Network.";


### PR DESCRIPTION
This PR addresses the issue of how to make the ext-community-type extensible. It does it by
- adding a string definition called 'raw', that allows for new and experimental sub-types to be defined, and the 'raw' string is followed by 8 bytes of hex values.
- moving the module to a IANA maintained module.