### PR TITLE
V14 policy

### DIFF
--- a/draft/draft-ietf-idr-bgp-model.xml
+++ b/draft/draft-ietf-idr-bgp-model.xml
@@ -1007,7 +1007,7 @@ INSERT_TEXT_FROM_FILE(../src/yang/example-bgp-configuration-a.1.3.xml,68)
 ]]></artwork>
         </figure>
       </section>
-      <section title="BGP Policy">
+      <section title="BGP Policy - Match Prefix and Set Community">
         <t>Routing policy using community value involves configuring
 	rules to match community values in the inbound or outbound
 	direction. In this example, which is heavily borrowed from
@@ -1038,6 +1038,18 @@ INSERT_TEXT_FROM_FILE(../src/yang/example-bgp-configuration-a.1.3.xml,68)
         <figure>
           <artwork><![CDATA[
 INSERT_TEXT_FROM_FILE(../src/yang/example-bgp-configuration-a.1.4.xml,68)
+
+]]></artwork>
+        </figure>
+      </section>
+            
+      <section title="BGP Policy - Match Next-hop and Set Community">
+        <t>In this example, a "next-hop-set" is configured using option "invert"
+          from "matct-set-options" to match next-hop not equal to "192.0.2.2" and
+          then set community to 55:55.</t>
+        <figure>
+          <artwork><![CDATA[
+INSERT_TEXT_FROM_FILE(../src/yang/example-bgp-configuration-a.1.5.xml,68)
 
 ]]></artwork>
         </figure>

--- a/src/yang/example-bgp-configuration-a.1.5.xml
+++ b/src/yang/example-bgp-configuration-a.1.5.xml
@@ -1,0 +1,39 @@
+<?xml version='1.0' encoding='UTF-8'?>
+  <routing-policy xmlns="urn:ietf:params:xml:ns:yang:ietf-routing-policy">
+    <defined-sets>
+      <bgp-defined-sets xmlns="urn:ietf:params:xml:ns:yang:ietf-bgp-policy">
+        <next-hop-sets>
+          <next-hop-set>
+            <name>nexthop_not2</name>
+            <next-hop>192.0.2.2</next-hop>
+          </next-hop-set>
+        </next-hop-sets>
+      </bgp-defined-sets>
+    </defined-sets>
+    <policy-definitions>
+      <policy-definition>
+        <name>nexthop_not2_community</name>
+        <statements>
+          <statement>
+            <name>100</name>
+            <conditions>
+              <bgp-conditions xmlns="urn:ietf:params:xml:ns:yang:ietf-bgp-policy">
+                <match-next-hop-set>
+                  <next-hop-set>nexthop_not2</next-hop-set>
+                  <match-set-options>invert</match-set-options>
+                </match-next-hop-set>
+              </bgp-conditions>
+            </conditions>
+            <actions>
+              <bgp-actions xmlns="urn:ietf:params:xml:ns:yang:ietf-bgp-policy">
+                <set-community>
+                  <options>add</options>
+                  <communities>55:55</communities>                  
+                </set-community>
+              </bgp-actions>
+            </actions>
+          </statement>
+        </statements>
+      </policy-definition>
+    </policy-definitions>
+  </routing-policy>

--- a/src/yang/ietf-bgp-policy.yang
+++ b/src/yang/ietf-bgp-policy.yang
@@ -7,15 +7,22 @@ module ietf-bgp-policy {
 
   import ietf-inet-types {
     prefix inet;
+    reference
+      "RFC 6991: Common YANG Data Types";
   }
   import ietf-routing-policy {
     prefix rt-pol;
+    reference
+      "RFC 9067: A YANG Data Model for Routing Policy";
   }
   import iana-bgp-types {
     prefix bt;
   }
   import ietf-routing-types {
     prefix rt-types;
+    reference
+      "RFC 8294 - Common YANG Data Types for the
+       Routing Area";
   }
 
   organization
@@ -28,7 +35,6 @@ module ietf-bgp-policy {
               Keyur Patel (keyur at arrcus.com),
               Susan Hares (shares at ndzh.com),
               Jeffrey Haas (jhaas at juniper.net).";
-
   description
     "This module contains data definitions for BGP routing policy.
      It augments the base routing-policy module with BGP-specific
@@ -54,7 +60,7 @@ module ietf-bgp-policy {
      described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
      they appear in all capitals, as shown here.";
 
-  revision YYYY-MM-DD {
+  revision 2022-07-03 {
     description
       "Initial Version";
     reference
@@ -107,7 +113,6 @@ module ietf-bgp-policy {
 
   typedef bgp-set-med-type {
     type union {
-      type uint32;
       type string {
         pattern '[+-]([0-9]{1,8}|[0-3][0-9]{1,9}|4[0-1][0-9]{1,8}|'
               + '428[0-9]{1,7}|429[0-3][0-9]{1,6}|42948[0-9]{1,5}|'
@@ -139,6 +144,7 @@ module ietf-bgp-policy {
              multiple ASs.";
         }
       }
+      type uint32;
     }
     description
       "Type definition for specifying how the BGP MED can
@@ -148,7 +154,6 @@ module ietf-bgp-policy {
   }
 
   // Identities
-
   // augment statements
 
   augment "/rt-pol:routing-policy/rt-pol:defined-sets" {
@@ -173,16 +178,15 @@ module ietf-bgp-policy {
           }
           leaf-list member {
             type union {
-              type bt:bgp-std-community-type;
+              //type bt:bgp-well-known-community-type;
+              //type bt:bgp-std-community-type;
               type bt:bgp-community-regexp-type;
-              type bt:bgp-well-known-community-type;
             }
             description
               "Members of the community set";
           }
         }
       }
-
       container ext-community-sets {
         description
           "Enclosing container for list of extended BGP community
@@ -199,7 +203,8 @@ module ietf-bgp-policy {
           }
           leaf-list member {
             type union {
-              type rt-types:route-target;
+              //type rt-types:route-target;
+              //type uint64;
               type bt:bgp-community-regexp-type;
             }
             description
@@ -207,7 +212,6 @@ module ietf-bgp-policy {
           }
         }
       }
-
       container large-community-sets {
         description
           "Enclosing container for list of large BGP community
@@ -224,7 +228,7 @@ module ietf-bgp-policy {
           }
           leaf-list member {
             type union {
-              type bt:bgp-large-community-type;
+              //type bt:bgp-large-community-type;
               type bt:bgp-community-regexp-type;
             }
             description
@@ -232,7 +236,6 @@ module ietf-bgp-policy {
           }
         }
       }
-
       container as-path-sets {
         description
           "Enclosing container for list of define AS path sets.";
@@ -246,7 +249,7 @@ module ietf-bgp-policy {
               "Name of the AS path set -- this is used to reference
                the set in match conditions.";
           }
-          leaf-list member {
+          leaf member {
             type string;
             description
               "AS path regular expression -- list of ASes in the
@@ -254,17 +257,14 @@ module ietf-bgp-policy {
           }
         }
       }
-
       container next-hop-sets {
         description
           "Definition of a list of IPv4 or IPv6 next-hops which can
            be matched in a routing policy.";
-
         list next-hop-set {
           key "name";
           description
             "List of defined next-hop sets for use in policies.";
-
           leaf name {
             type string;
             description
@@ -280,59 +280,51 @@ module ietf-bgp-policy {
     }
   }
 
-  augment "/rt-pol:routing-policy/rt-pol:policy-definitions/" +
-          "rt-pol:policy-definition/rt-pol:statements/" +
-          "rt-pol:statement/rt-pol:conditions" {
+  augment "/rt-pol:routing-policy/rt-pol:policy-definitions/"
+        + "rt-pol:policy-definition/rt-pol:statements/"
+        + "rt-pol:statement/rt-pol:conditions" {
     description
       "BGP policy conditions added to routing policy module.";
-
     container bgp-conditions {
       description
         "Top-level container for BGP specific policy conditions.";
-
-      leaf med-eq {
+      leaf med-eq {         //** lt or gt
         type uint32;
         description
           "Condition to check if the received MED value is equal to
            the specified value.";
       }
-
       leaf origin-eq {
         type bt:bgp-origin-attr-type;
         description
           "Condition to check if the route origin is equal to the
            specified value.";
       }
-
-      leaf-list next-hop-in-eq {
+      leaf-list next-hop-in-eq {     //***should this be leaf-list or leaf?
         type inet:ip-address-no-zone;
         description
           "List of next hop addresses to check for in the route
            update.";
       }
-
-      leaf-list afi-safi-in {
+      leaf-list afi-safi-in {        //** leaf? or?
         type identityref {
           base bt:afi-safi-type;
         }
         description
           "List of address families which the NLRI may be within.";
       }
-
-      leaf local-pref-eq {
+      leaf local-pref-eq {          //** lt or gt?
         type uint32;
         description
           "Condition to check if the local pref attribute is equal to
            the specified value.";
       }
-
-      leaf-list neighbor-eq {
+      leaf-list neighbor-eq {       //** leaf?
         type inet:ip-address;
         description
           "List of neighbor addresses to check for in the ingress
            direction.";
       }
-
       leaf route-type {
         type enumeration {
           enum internal {
@@ -347,19 +339,16 @@ module ietf-bgp-policy {
         description
           "Condition to check the route type in the route update.";
       }
-
       container community-count {
         description
           "Value and comparison operations for conditions based on
            the number of communities in the route update.";
-
         leaf community-count {
           type uint32;
           description
             "Value for the number of communities in the route
              update.";
         }
-
         choice operation {
           case eq {
             leaf eq {
@@ -368,7 +357,6 @@ module ietf-bgp-policy {
                 "Check to see if the value is equal.";
             }
           }
-
           case lt-or-eq {
             leaf lt-or-eq {
               type empty;
@@ -376,7 +364,6 @@ module ietf-bgp-policy {
                 "Check to see if the value is less than or equal.";
             }
           }
-
           case gt-or-eq {
             leaf gt-or-eq {
               type empty;
@@ -389,7 +376,6 @@ module ietf-bgp-policy {
             "Choice of operations on the value of community-count.";
         }
       }
-
       container as-path-length {
         description
           "Value and comparison operations for conditions based on
@@ -399,13 +385,11 @@ module ietf-bgp-policy {
            RFC 4271 rules.";
         reference
           "RFC 4271: BGP-4.";
-
         leaf as-path-length {
           type uint32;
           description
             "Value of the AS path length in the route update.";
         }
-
         choice operation {
           case eq {
             leaf eq {
@@ -414,7 +398,6 @@ module ietf-bgp-policy {
                 "Check to see if the value is equal.";
             }
           }
-
           case lt-or-eq {
             leaf lt-or-eq {
               type empty;
@@ -422,7 +405,6 @@ module ietf-bgp-policy {
                 "Check to see if the value is less than or equal.";
             }
           }
-
           case gt-or-eq {
             leaf gt-or-eq {
               type empty;
@@ -435,7 +417,6 @@ module ietf-bgp-policy {
             "Choice of operations on the value of as-path-len.";
         }
       }
-
       container match-community-set {
         description
           "Top-level container for match conditions on communities.
@@ -452,7 +433,6 @@ module ietf-bgp-policy {
         }
         uses rt-pol:match-set-options-group;
       }
-
       container match-ext-community-set {
         description
           "Match a referenced extended community-set according to the
@@ -468,7 +448,6 @@ module ietf-bgp-policy {
         }
         uses rt-pol:match-set-options-group;
       }
-
       container match-large-community-set {
         description
           "Match a referenced large community-set according to the
@@ -484,7 +463,6 @@ module ietf-bgp-policy {
         }
         uses rt-pol:match-set-options-group;
       }
-
       container match-as-path-set {
         description
           "Match a referenced as-path set according to the logic
@@ -500,7 +478,6 @@ module ietf-bgp-policy {
         }
         uses rt-pol:match-set-options-group;
       }
-
       container match-next-hop-set {
         description
           "Match a referenced next-hop set according to the logic
@@ -519,9 +496,9 @@ module ietf-bgp-policy {
     }
   }
 
-  augment "/rt-pol:routing-policy/rt-pol:policy-definitions/" +
-          "rt-pol:policy-definition/rt-pol:statements/" +
-          "rt-pol:statement/rt-pol:actions" {
+  augment "/rt-pol:routing-policy/rt-pol:policy-definitions/"
+        + "rt-pol:policy-definition/rt-pol:statements/"
+        + "rt-pol:statement/rt-pol:actions" {
     description
       "BGP policy actions added to routing policy module.";
     container bgp-actions {
@@ -551,25 +528,33 @@ module ietf-bgp-policy {
         description
           "Action to prepend local AS number to the AS-path a
            specified number of times";
-
-        leaf repeat-n {
-          type uint8 {
-            range "1..max";
-          }
+        list as-path-prepend {
+          key "asn";
           description
-            "Number of times to prepend the local AS number to the AS
-             path.  The value should be between 1 and the maximum
-             supported by the implementation.";
+            "List of AS numbers to prepend.";
+          leaf repeat-n {
+            type uint8 {
+              range "1..max";
+            }
+            description
+              "Number of times to prepend the AS number to the AS
+               path. The value should be between 1 and the maximum
+               supported by the implementation.";
+          }
+          leaf asn {
+            type inet:as-number;
+            description
+              "AS number to prepend to the AS path. If not specified,
+               then the local AS number will be used for prepending.";
+          }
         }
       }
-
       container set-community {
         description
           "Action to set the community attributes of the route, along
            with options to modify how the community is modified.
            Communities may be set using an inline list OR
            reference to an existing defined set (not both).";
-
         leaf options {
           type bgp-set-community-option-type;
           description
@@ -577,7 +562,6 @@ module ietf-bgp-policy {
              the specified values.  These options apply to both
              methods of setting the community attribute.";
         }
-
         choice method {
           description
             "Indicates the method used to specify the extended
@@ -585,15 +569,14 @@ module ietf-bgp-policy {
           case inline {
             leaf-list communities {
               type union {
-                type bt:bgp-std-community-type;
                 type bt:bgp-well-known-community-type;
+                type bt:bgp-std-community-type;
               }
               description
                 "Set the community values for the update inline with
                  a list.";
             }
           }
-
           case reference {
             leaf community-set-ref {
               type leafref {
@@ -607,7 +590,6 @@ module ietf-bgp-policy {
           }
         }
       }
-
       container set-ext-community {
         description
           "Action to set the extended community attributes of the
@@ -615,7 +597,6 @@ module ietf-bgp-policy {
            modified. Extended communities may be set using an inline
            list OR a reference to an existing defined set (but not
            both).";
-
         leaf options {
           type bgp-set-community-option-type;
           description
@@ -623,7 +604,6 @@ module ietf-bgp-policy {
              the specified values.  These options apply to both
              methods of setting the community attribute.";
         }
-
         choice method {
           description
             "Indicates the method used to specify the extended
@@ -650,7 +630,6 @@ module ietf-bgp-policy {
           }
         }
       }
-
       container set-large-community {
         description
           "Action to set the large community attributes of the
@@ -658,7 +637,6 @@ module ietf-bgp-policy {
            modified. Large communities may be set using an inline
            list OR a reference to an existing defined set (but not
            both).";
-
         leaf options {
           type bgp-set-community-option-type;
           description
@@ -666,7 +644,6 @@ module ietf-bgp-policy {
              the specified values. These options apply to both
              methods of setting the community attribute.";
         }
-
         choice method {
           description
             "Indicates the method used to specify the large

--- a/src/yang/ietf-bgp-policy.yang
+++ b/src/yang/ietf-bgp-policy.yang
@@ -607,6 +607,7 @@ module ietf-bgp-policy {
                  a list.";
             }
           }
+          
           case reference {
             leaf community-set-ref {
               type leafref {

--- a/src/yang/ietf-bgp-policy.yang
+++ b/src/yang/ietf-bgp-policy.yang
@@ -607,7 +607,7 @@ module ietf-bgp-policy {
                  a list.";
             }
           }
- 
+
           case reference {
             leaf community-set-ref {
               type leafref {

--- a/src/yang/ietf-bgp-policy.yang
+++ b/src/yang/ietf-bgp-policy.yang
@@ -179,7 +179,11 @@ module ietf-bgp-policy {
                reference the set in match conditions.";
           }
           leaf-list member {
-            type bt:bgp-community-regexp-type;
+            type union {
+              type bt:bgp-well-known-community-type;
+              type bt:bgp-std-community-type;
+              type bt:bgp-community-regexp-type;
+            }
             description
               "Members of the community set";
           }
@@ -201,7 +205,10 @@ module ietf-bgp-policy {
                used to reference the set in match conditions";
           }
           leaf-list member {
-            type bt:bgp-community-regexp-type;
+            type union {
+              type rt-types:route-target;
+              type bt:bgp-community-regexp-type;
+            }
             description
               "Members of the extended community set.";
           }
@@ -223,7 +230,10 @@ module ietf-bgp-policy {
                used to reference the set in match conditions";
           }
           leaf-list member {
-            type bt:bgp-community-regexp-type;
+            type union {
+              type bt:bgp-large-community-type;
+              type bt:bgp-community-regexp-type;
+            }
             description
               "Members of the large community set.";
           }
@@ -243,11 +253,12 @@ module ietf-bgp-policy {
               "Name of the AS path set -- this is used to reference
                the set in match conditions.";
           }
-          leaf member {
+          leaf-list member {
             type string;
             description
               "AS path regular expression -- list of ASes in the
-               set.";
+               set. If any of the regualr expression in the lists
+               is matched, the as-path-set is considered matched.";
           }
         }
       }
@@ -277,9 +288,9 @@ module ietf-bgp-policy {
     }
   }
 
-  augment "/rt-pol:routing-policy/rt-pol:policy-definitions/"
-        + "rt-pol:policy-definition/rt-pol:statements/"
-        + "rt-pol:statement/rt-pol:conditions" {
+  augment "/rt-pol:routing-policy/rt-pol:policy-definitions/" +
+          "rt-pol:policy-definition/rt-pol:statements/" +
+          "rt-pol:statement/rt-pol:conditions" {
     description
       "BGP policy conditions added to routing policy module.";
 
@@ -517,14 +528,14 @@ module ietf-bgp-policy {
           description
             "Reference a defined next-hop set.";
         }
-        uses rt-pol:match-set-options-group;
+        uses rt-pol:match-set-options-restricted-group;
       }
     }
   }
 
-  augment "/rt-pol:routing-policy/rt-pol:policy-definitions/"
-        + "rt-pol:policy-definition/rt-pol:statements/"
-        + "rt-pol:statement/rt-pol:actions" {
+  augment "/rt-pol:routing-policy/rt-pol:policy-definitions/" +
+          "rt-pol:policy-definition/rt-pol:statements/" +
+          "rt-pol:statement/rt-pol:actions" {
     description
       "BGP policy actions added to routing policy module.";
     container bgp-actions {
@@ -555,25 +566,20 @@ module ietf-bgp-policy {
         description
           "Action to prepend local AS number to the AS-path a
            specified number of times";
-        list as-path-prepend {
-          key "asn";
+
+        leaf repeat-n {
+          type uint8 {
+            range "1..max";
+          }
           description
-            "List of AS numbers to prepend.";
-          leaf repeat-n {
-            type uint8 {
-              range "1..max";
-            }
-            description
-              "Number of times to prepend the AS number to the AS
-               path. The value should be between 1 and the maximum
-               supported by the implementation.";
-          }
-          leaf asn {
-            type inet:as-number;
-            description
-              "AS number to prepend to the AS path. If not specified,
-               then the local AS number will be used for prepending.";
-          }
+            "Number of times to prepend the AS number to the AS
+             path. The value should be between 1 and the maximum
+             supported by the implementation.";
+        }
+        leaf-list asn {
+          type inet:as-number;
+          description
+            "AS number to prepend to the AS path.";
         }
       }
 

--- a/src/yang/ietf-bgp-policy.yang
+++ b/src/yang/ietf-bgp-policy.yang
@@ -607,7 +607,7 @@ module ietf-bgp-policy {
                  a list.";
             }
           }
-          
+ 
           case reference {
             leaf community-set-ref {
               type leafref {

--- a/src/yang/ietf-bgp-policy.yang
+++ b/src/yang/ietf-bgp-policy.yang
@@ -35,6 +35,7 @@ module ietf-bgp-policy {
               Keyur Patel (keyur at arrcus.com),
               Susan Hares (shares at ndzh.com),
               Jeffrey Haas (jhaas at juniper.net).";
+
   description
     "This module contains data definitions for BGP routing policy.
      It augments the base routing-policy module with BGP-specific
@@ -60,7 +61,7 @@ module ietf-bgp-policy {
      described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
      they appear in all capitals, as shown here.";
 
-  revision 2022-07-03 {
+  revision YYYY-MM-DD {
     description
       "Initial Version";
     reference
@@ -154,6 +155,7 @@ module ietf-bgp-policy {
   }
 
   // Identities
+
   // augment statements
 
   augment "/rt-pol:routing-policy/rt-pol:defined-sets" {
@@ -178,8 +180,6 @@ module ietf-bgp-policy {
           }
           leaf-list member {
             type union {
-              //type bt:bgp-well-known-community-type;
-              //type bt:bgp-std-community-type;
               type bt:bgp-community-regexp-type;
             }
             description
@@ -187,6 +187,7 @@ module ietf-bgp-policy {
           }
         }
       }
+
       container ext-community-sets {
         description
           "Enclosing container for list of extended BGP community
@@ -212,6 +213,7 @@ module ietf-bgp-policy {
           }
         }
       }
+
       container large-community-sets {
         description
           "Enclosing container for list of large BGP community
@@ -236,6 +238,7 @@ module ietf-bgp-policy {
           }
         }
       }
+
       container as-path-sets {
         description
           "Enclosing container for list of define AS path sets.";
@@ -257,14 +260,17 @@ module ietf-bgp-policy {
           }
         }
       }
+
       container next-hop-sets {
         description
           "Definition of a list of IPv4 or IPv6 next-hops which can
            be matched in a routing policy.";
+
         list next-hop-set {
           key "name";
           description
             "List of defined next-hop sets for use in policies.";
+
           leaf name {
             type string;
             description
@@ -285,46 +291,74 @@ module ietf-bgp-policy {
         + "rt-pol:statement/rt-pol:conditions" {
     description
       "BGP policy conditions added to routing policy module.";
+
     container bgp-conditions {
       description
         "Top-level container for BGP specific policy conditions.";
+
       leaf med-eq {         //** lt or gt
         type uint32;
         description
           "Condition to check if the received MED value is equal to
            the specified value.";
       }
+
       leaf origin-eq {
         type bt:bgp-origin-attr-type;
         description
           "Condition to check if the route origin is equal to the
            specified value.";
       }
-      leaf-list next-hop-in-eq {     //***should this be leaf-list or leaf?
-        type inet:ip-address-no-zone;
+
+      container match-next-hop {
         description
-          "List of next hop addresses to check for in the route
-           update.";
-      }
-      leaf-list afi-safi-in {        //** leaf? or?
-        type identityref {
-          base bt:afi-safi-type;
+          "Match a next hop addresses according to the logic defined in
+           the match-set-options leaf.";
+
+        leaf-list next-hop {
+          type inet:ip-address-no-zone;
+          description
+            "List of next hop addresses to check for in the route
+             update.";
         }
-        description
-          "List of address families which the NLRI may be within.";
+        uses rt-pol:match-set-options-restricted-group;
       }
-      leaf local-pref-eq {          //** lt or gt?
+
+      container match-afi-safi {
+        description
+          "Match an address family according to the logic defined in
+           the match-set-options leaf.";
+        leaf-list afi-safi-in {
+          type identityref {
+            base bt:afi-safi-type;
+          }
+          description
+            "List of address families which the NLRI may be within.";
+        }
+        uses rt-pol:match-set-options-restricted-group;
+      }
+
+      leaf local-pref-eq {
         type uint32;
         description
           "Condition to check if the local pref attribute is equal to
            the specified value.";
       }
-      leaf-list neighbor-eq {       //** leaf?
-        type inet:ip-address;
+
+      container match-neighbor {
         description
-          "List of neighbor addresses to check for in the ingress
-           direction.";
+          "Match a neighbor according to the logic defined in the
+           match-set-options leaf.";
+
+        leaf-list neighbor-eq {
+          type inet:ip-address;
+          description
+            "List of neighbor addresses to check for in the ingress
+             direction.";
+        }
+        uses rt-pol:match-set-options-restricted-group;
       }
+
       leaf route-type {
         type enumeration {
           enum internal {
@@ -339,16 +373,19 @@ module ietf-bgp-policy {
         description
           "Condition to check the route type in the route update.";
       }
+
       container community-count {
         description
           "Value and comparison operations for conditions based on
            the number of communities in the route update.";
+
         leaf community-count {
           type uint32;
           description
             "Value for the number of communities in the route
              update.";
         }
+
         choice operation {
           case eq {
             leaf eq {
@@ -376,6 +413,7 @@ module ietf-bgp-policy {
             "Choice of operations on the value of community-count.";
         }
       }
+
       container as-path-length {
         description
           "Value and comparison operations for conditions based on
@@ -385,11 +423,13 @@ module ietf-bgp-policy {
            RFC 4271 rules.";
         reference
           "RFC 4271: BGP-4.";
+
         leaf as-path-length {
           type uint32;
           description
             "Value of the AS path length in the route update.";
         }
+
         choice operation {
           case eq {
             leaf eq {
@@ -417,6 +457,7 @@ module ietf-bgp-policy {
             "Choice of operations on the value of as-path-len.";
         }
       }
+
       container match-community-set {
         description
           "Top-level container for match conditions on communities.
@@ -524,6 +565,7 @@ module ietf-bgp-policy {
         description
           "Set the med metric attribute in the route.";
       }
+
       container set-as-path-prepend {
         description
           "Action to prepend local AS number to the AS-path a
@@ -549,12 +591,14 @@ module ietf-bgp-policy {
           }
         }
       }
+
       container set-community {
         description
           "Action to set the community attributes of the route, along
            with options to modify how the community is modified.
            Communities may be set using an inline list OR
            reference to an existing defined set (not both).";
+
         leaf options {
           type bgp-set-community-option-type;
           description
@@ -562,6 +606,7 @@ module ietf-bgp-policy {
              the specified values.  These options apply to both
              methods of setting the community attribute.";
         }
+
         choice method {
           description
             "Indicates the method used to specify the extended
@@ -590,6 +635,7 @@ module ietf-bgp-policy {
           }
         }
       }
+
       container set-ext-community {
         description
           "Action to set the extended community attributes of the
@@ -597,6 +643,7 @@ module ietf-bgp-policy {
            modified. Extended communities may be set using an inline
            list OR a reference to an existing defined set (but not
            both).";
+
         leaf options {
           type bgp-set-community-option-type;
           description
@@ -604,6 +651,7 @@ module ietf-bgp-policy {
              the specified values.  These options apply to both
              methods of setting the community attribute.";
         }
+
         choice method {
           description
             "Indicates the method used to specify the extended
@@ -630,6 +678,7 @@ module ietf-bgp-policy {
           }
         }
       }
+
       container set-large-community {
         description
           "Action to set the large community attributes of the
@@ -637,6 +686,7 @@ module ietf-bgp-policy {
            modified. Large communities may be set using an inline
            list OR a reference to an existing defined set (but not
            both).";
+
         leaf options {
           type bgp-set-community-option-type;
           description
@@ -644,6 +694,7 @@ module ietf-bgp-policy {
              the specified values. These options apply to both
              methods of setting the community attribute.";
         }
+
         choice method {
           description
             "Indicates the method used to specify the large

--- a/src/yang/ietf-bgp-policy.yang
+++ b/src/yang/ietf-bgp-policy.yang
@@ -179,9 +179,7 @@ module ietf-bgp-policy {
                reference the set in match conditions.";
           }
           leaf-list member {
-            type union {
-              type bt:bgp-community-regexp-type;
-            }
+            type bt:bgp-community-regexp-type;
             description
               "Members of the community set";
           }
@@ -203,11 +201,7 @@ module ietf-bgp-policy {
                used to reference the set in match conditions";
           }
           leaf-list member {
-            type union {
-              //type rt-types:route-target;
-              //type uint64;
-              type bt:bgp-community-regexp-type;
-            }
+            type bt:bgp-community-regexp-type;
             description
               "Members of the extended community set.";
           }
@@ -229,10 +223,7 @@ module ietf-bgp-policy {
                used to reference the set in match conditions";
           }
           leaf-list member {
-            type union {
-              //type bt:bgp-large-community-type;
-              type bt:bgp-community-regexp-type;
-            }
+            type bt:bgp-community-regexp-type;
             description
               "Members of the large community set.";
           }
@@ -296,7 +287,7 @@ module ietf-bgp-policy {
       description
         "Top-level container for BGP specific policy conditions.";
 
-      leaf med-eq {         //** lt or gt
+      leaf med-eq {
         type uint32;
         description
           "Condition to check if the received MED value is equal to
@@ -308,20 +299,6 @@ module ietf-bgp-policy {
         description
           "Condition to check if the route origin is equal to the
            specified value.";
-      }
-
-      container match-next-hop {
-        description
-          "Match a next hop addresses according to the logic defined in
-           the match-set-options leaf.";
-
-        leaf-list next-hop {
-          type inet:ip-address-no-zone;
-          description
-            "List of next hop addresses to check for in the route
-             update.";
-        }
-        uses rt-pol:match-set-options-restricted-group;
       }
 
       container match-afi-safi {
@@ -394,6 +371,7 @@ module ietf-bgp-policy {
                 "Check to see if the value is equal.";
             }
           }
+
           case lt-or-eq {
             leaf lt-or-eq {
               type empty;
@@ -401,6 +379,7 @@ module ietf-bgp-policy {
                 "Check to see if the value is less than or equal.";
             }
           }
+
           case gt-or-eq {
             leaf gt-or-eq {
               type empty;
@@ -438,6 +417,7 @@ module ietf-bgp-policy {
                 "Check to see if the value is equal.";
             }
           }
+
           case lt-or-eq {
             leaf lt-or-eq {
               type empty;
@@ -445,6 +425,7 @@ module ietf-bgp-policy {
                 "Check to see if the value is less than or equal.";
             }
           }
+
           case gt-or-eq {
             leaf gt-or-eq {
               type empty;
@@ -474,6 +455,7 @@ module ietf-bgp-policy {
         }
         uses rt-pol:match-set-options-group;
       }
+
       container match-ext-community-set {
         description
           "Match a referenced extended community-set according to the
@@ -489,6 +471,7 @@ module ietf-bgp-policy {
         }
         uses rt-pol:match-set-options-group;
       }
+
       container match-large-community-set {
         description
           "Match a referenced large community-set according to the
@@ -504,6 +487,7 @@ module ietf-bgp-policy {
         }
         uses rt-pol:match-set-options-group;
       }
+
       container match-as-path-set {
         description
           "Match a referenced as-path set according to the logic
@@ -519,6 +503,7 @@ module ietf-bgp-policy {
         }
         uses rt-pol:match-set-options-group;
       }
+
       container match-next-hop-set {
         description
           "Match a referenced next-hop set according to the logic


### PR DESCRIPTION
summary of change:
added references
for community, changed type from union to string only
removed next-hop-in-eq since there is match-next-hop-set
changed afi-safi-in and neighbor-eq to container with match-set-options
changed as-path-prepend to allow any ASN prepending