### PR TITLE
Dump capabilities

### DIFF
--- a/draft/Makefile
+++ b/draft/Makefile
@@ -50,8 +50,9 @@ endif
 	-rm -f ../bin/submodules/*\@$(shell date +%Y)*.yang
 	-rm -f ../bin/submodules/*\@$(shell date +%Y)*-*-*.yang
 
-$(next).xml: $(draft).xml ../src/yang/ietf-bgp-common-multiprotocol.yang ../src/yang/ietf-bgp-common-structure.yang ../src/yang/ietf-bgp-common.yang ../src/yang/ietf-bgp-neighbor.yang ../src/yang/ietf-bgp-policy.yang ../src/yang/iana-bgp-types.yang ../src/yang/ietf-bgp.yang rib
+$(next).xml: $(draft).xml ../src/yang/ietf-bgp-capabilities.yang ../src/yang/ietf-bgp-common-multiprotocol.yang ../src/yang/ietf-bgp-common-structure.yang ../src/yang/ietf-bgp-common.yang ../src/yang/ietf-bgp-neighbor.yang ../src/yang/ietf-bgp-policy.yang ../src/yang/iana-bgp-types.yang ../src/yang/ietf-bgp.yang rib
 	sed -e"s/$(basename $<)-latest/$(basename $@)/" -e"s/YYYY-MM-DD/$(shell date +%Y-%m-%d)/" $< > $@
+	sed -e"s/YYYY-MM-DD/$(shell date +%Y-%m-%d)/" ../src/yang/ietf-bgp-capabilities.yang > ../bin/submodules/ietf-bgp-capabilities\@$(shell date +%Y-%m-%d).yang
 	sed -e"s/YYYY-MM-DD/$(shell date +%Y-%m-%d)/" ../src/yang/ietf-bgp-common-multiprotocol.yang > ../bin/submodules/ietf-bgp-common-multiprotocol\@$(shell date +%Y-%m-%d).yang
 	sed -e"s/YYYY-MM-DD/$(shell date +%Y-%m-%d)/" ../src/yang/ietf-bgp-common-structure.yang > ../bin/submodules/ietf-bgp-common-structure\@$(shell date +%Y-%m-%d).yang
 	sed -e"s/YYYY-MM-DD/$(shell date +%Y-%m-%d)/" ../src/yang/ietf-bgp-common.yang > ../bin/submodules/ietf-bgp-common\@$(shell date +%Y-%m-%d).yang

--- a/draft/draft-ietf-idr-bgp-model.xml
+++ b/draft/draft-ietf-idr-bgp-model.xml
@@ -501,26 +501,28 @@ INSERT_TEXT_FROM_FILE(../bin/ietf-bgp@YYYY-MM-DD-rib-tree.txt)
       operations. Some of the subtrees and data nodes and their
       sensitivity/vulnerability are described here.</t>
 
-      <t>- The attribute 'as'. If a user is allowed to change this attribute,
+      <ul>
+      <li> The attribute 'as'. If a user is allowed to change this attribute,
       it will have the net effect of bringing down the entire routing
       instance, causing it to delete all the current routing entries, and
-      learning new ones.</t>
+      learning new ones.</li>
 
-      <t>- The attribute 'identifier'. If a user is allowed to change this
+      <li> The attribute 'identifier'. If a user is allowed to change this
       attribute, it will have the net effect of this routing instance
-      re-advertising all its routes.</t>
+      re-advertising all its routes.</li>
 
-      <t>- The attribute 'distance'. If a user is allowed to change this
+      <li> The attribute 'distance'. If a user is allowed to change this
       attribute, it will cause the preference for routes, e.g. external vs
-      internal to change.</t>
+      internal to change.</li>
 
-      <t>- The attribute 'enabled' in the 'confederation' container. This
-      attribute defines whether a local-AS is part of a BGP federation.</t>
+      <li> The attribute 'enabled' in the 'confederation' container. This
+      attribute defines whether a local-AS is part of a BGP confederation.</li>
 
-      <t>- Finally, there are a whole set of route selection options such as
+      <li> Finally, there are a whole set of route selection options such as
       'always-compare-med', 'ignore-as-path-length' that affect the way the
       system picks up a particular route. Being able to change will adversely
-      affect how the route selection happens.</t>
+      affect how the route selection happens.</li>
+      </ul>
 
       <t>Some of the readable data nodes in this YANG module may be considered
       sensitive or vulnerable in some network environments. It is thus
@@ -528,34 +530,38 @@ INSERT_TEXT_FROM_FILE(../bin/ietf-bgp@YYYY-MM-DD-rib-tree.txt)
       notification) to these data nodes. Some of the subtrees and data nodes
       and their sensitivity/vulnerability are:</t>
 
-      <t>- The list of neighbors, and their attributes. Allowing a user to
+      <ul>
+      <li> The list of neighbors, and their attributes. Allowing a user to
       read these attributes, in particular the address/port information may
       allow a malicious user to launch an attack at the particular
-      address/port.</t>
+      address/port.</li>
 
-      <t>- The 'rib' container. This container contains sensitive information
-      such as attribute sets, communities and external communities. Being able
-      to read the contents of this container will allow a malicious user to
-      understand how the system decide how to route a packet, and thus try to
-      affect a change.</t>
+      <li> The 'rib' container. This container contains sensitive information
+      such as attribute sets, communities, extended communities, and large
+      communities. Being able to read the contents of this container will allow
+      a malicious user to understand how the system decide how to route a
+      packet, and thus try to affect a change.</li>
+      </ul>
 
       <t>Some of the RPC operations in this YANG module may be considered
       sensitive or vulnerable in some network environments. It is thus
       important to control access to these operations. These are the
       operations and their sensitivity/vulnerability:</t>
 
-      <t>- The model allows for routes to be cleared using the 'clear' RPC
-      operations, causing the entire RIB table to be cleared.</t>
+      <ul>
+      <li> The model allows for routes to be cleared using the 'clear' RPC
+      operations, causing the entire RIB table to be cleared.</li>
 
-      <t>- The model allows for statistics to be cleared by the 'clear' RPC
-      operation, causing all the individual statistics to be cleared.</t>
+      <li> The model allows for statistics to be cleared by the 'clear' RPC
+      operation, causing all the individual statistics to be cleared.</li>
 
-      <t>- The model also allows for neighbors that have been learnt by the
-      system to be cleared by using the 'clear' RPC operation.</t>
+      <li> The model also allows for neighbors that have been learnt by the
+      system to be cleared by using the 'clear' RPC operation.</li>
+      </ul>
 
       <t><xref target="RFC7454">BGP OPSEC</xref> describes several
-      policies that can be used to secure a BGP. In particular, it
-      recommends securing the underlying TCP session and to use <xref
+      policies that can be used to secure BGP. In particular, it
+      recommends securing the underlying TCP session and to use the <xref
       target="RFC5082">Generalized TTL Security Mechanism
       (GTSM)</xref> capability to make it harder to spoof a BGP
       session. This module allows implementations that want to support
@@ -618,75 +624,71 @@ reference: RFC XXXX
       below.</t>
 
       <t>The main module, ietf-bgp.yang, includes the following submodules:
-      <list style="symbols">
-          <t>ietf-bgp-common - defines the groupings that are common across
+      <ul>
+          <li>ietf-bgp-common - defines the groupings that are common across
           more than one context (where contexts are neighbor, group,
-          global)</t>
+          global).</li>
 
-          <t>ietf-bgp-common-multiprotocol - defines the groupings that are
+          <li>ietf-bgp-common-multiprotocol - defines the groupings that are
           common across more than one context, and relate to multi-protocol
-          BGP</t>
+          BGP.</li>
 
-          <t>ietf-bgp-common-structure - defines groupings that are shared by
-          multiple contexts, but are used only to create structural elements,
-          i.e., containers (leaf nodes are defined in separate groupings)</t>
+          <li>ietf-bgp-common-structure - defines groupings that are shared by
+          multiple contexts, but are used only to create structural elements;
+          i.e., containers (leaf nodes are defined in separate groupings).</li>
 
-          <t>ietf-bgp-neighbor - groupings with data specific to the neighbor
-          context</t>
+          <li>ietf-bgp-neighbor - groupings with data specific to the neighbor
+          context.</li>
 
-          <t>ietf-bgp-rib - grouping for representing BGP RIB.</t>
-	  <t>ietf-bgp-rib-attributes - common data definitions for BGP
-	  attributes used in BGP RIB tables.</t>
-	  <t>ietf-bgp-rib-tables - structural data definitions for BGP
-	  routing tables.</t>
-        </list></t>
+          <li>ietf-bgp-rib - grouping for representing BGP RIBs.</li>
+	  <li>ietf-bgp-rib-attributes - common data definitions for BGP
+	  attributes used in BGP RIB tables.</li>
+	  <li>ietf-bgp-rib-tables - structural data definitions for BGP
+	  routing tables.</li>
+        </ul></t>
 
-      <t>Additionally, modules include: <list style="symbols">
-          <t>iana-bgp-types - common type and identity definitions for BGP,
-          including BGP policy</t>
+      <t>Additionally, modules include:
+      <ul>
+          <li>iana-bgp-types - common type and identity definitions for BGP,
+          including BGP policy.</li>
 
-          <t>ietf-bgp-policy - BGP-specific policy data definitions for use
+          <li>ietf-bgp-policy - BGP-specific policy data definitions for use
           with <xref target="RFC9067"/> (described in more
-          detail <xref target="overview.policy"/>)</t>
-        </list></t>
+          detail <xref target="overview.policy"/>).</li>
+        </ul></t>
     </section>
 
     <section title="Structure of the YANG modules">
       <t>The YANG model can be subdivided between the main module for
-      base items, types, and policy module. It references <xref
-      target="RFC1997">BGP Communities Attribute </xref>, <xref
-      target="RFC2918">Route Refresh Capability for BGP-4</xref>,
-      <xref target="RFC3765">NOPEER Community for BGP</xref>, <xref
-      target="RFC4360">BGP Extended Communities Attributes</xref>,
-      <xref target="RFC4364">BGP/MPLS IP Virtual Private Networks
-      (VPNs)</xref>, <xref target="RFC4451">BGP MED
-      Considerations</xref>, <xref target="RFC4659">BGP-MPLS IP
-      Virtual Private Network (VPN) Extension for IPv6 VPN</xref>,
-      <xref target="RFC4724">Graceful Restart Mechanism for
-      BGP</xref>, <xref target="RFC4760">Multiprotocol Extentions for
-      BGP-4</xref>, <xref target="RFC4761">Virtual Private LAN Service
-      (VPLS) Using BGP for Auto-Discovery and Signaling</xref>, <xref
-      target="RFC5065">Autonomous System Configuration for BGP</xref>,
-      <xref target="RFC5082">The Generalized TTL Security Mechanism
-      (GTSM)</xref>, <xref target="RFC5880">Bidirectional Forward
-      Detection (BFD)</xref>, <xref target="RFC5881">Bidirectional
-      Forward Detection for IPv4 and IPv6 (Single Hop)</xref>, <xref
-      target="RFC5883">Bidirectional Forwarding Detection (BFD) for
-      Multihop Paths</xref>, <xref target="RFC5925">The TCP
-      Authentication Option</xref>, <xref target="RFC6514">BGP
-      Encodings and Procedures for Multicast in MPLS/BGP IP
-      VPNs</xref>, <xref target="RFC6793">BGP Support for Four-Octet
-      Autonomous System (AS) Number Space</xref>, <xref
-      target="RFC7911">Advertisement of Multiple Paths in BGP </xref>,
-      <xref target="RFC8092">BGP Large Communities Attributes</xref>,
-      <xref target="RFC8177">YANG Key Chain</xref>, <xref
-      target="RFC8277">Carrying Label Information in BGP-4 </xref>,
-      <xref target="RFC9067">A YANG Data Model for Routing
-      Policy</xref>, <xref target="RFC9314">YANG Data Model for
-      Bidirectional Forward Detection</xref>, <xref
-      target="RFC9293">Transmission Control Protocol</xref>, and <xref
-      target="I-D.ietf-tcpm-yang-tcp">YANG Model for Transmission
-      Control Protocol (TCP) Configuration</xref>.</t>
+      base items, types, and policy module. It references:
+      <ul>
+      <li><xref target="RFC1997">BGP Communities Attribute </xref></li>
+      <li><xref target="RFC2918">Route Refresh Capability for BGP-4</xref></li>
+      <li><xref target="RFC3765">NOPEER Community for BGP</xref></li>
+      <li><xref target="RFC4360">BGP Extended Communities Attributes</xref></li>
+      <li><xref target="RFC4364">BGP/MPLS IP Virtual Private Networks (VPNs)</xref></li>
+      <li><xref target="RFC4451">BGP MED Considerations</xref></li>
+      <li><xref target="RFC4659">BGP-MPLS IP Virtual Private Network (VPN) Extension for IPv6 VPN</xref></li>
+      <li><xref target="RFC4724">Graceful Restart Mechanism for BGP</xref></li>
+      <li><xref target="RFC4760">Multiprotocol Extentions for BGP-4</xref></li>
+      <li><xref target="RFC4761">Virtual Private LAN Service (VPLS) Using BGP for Auto-Discovery and Signaling</xref></li>
+      <li><xref target="RFC5065">Autonomous System Configuration for BGP</xref></li>
+      <li><xref target="RFC5082">The Generalized TTL Security Mechanism (GTSM)</xref></li>
+      <li><xref target="RFC5880">Bidirectional Forward Detection (BFD)</xref></li>
+      <li><xref target="RFC5881">Bidirectional Forward Detection for IPv4 and IPv6 (Single Hop)</xref></li>
+      <li><xref target="RFC5883">Bidirectional Forwarding Detection (BFD) for Multihop Paths</xref></li>
+      <li><xref target="RFC5925">The TCP Authentication Option</xref></li>
+      <li><xref target="RFC6514">BGP Encodings and Procedures for Multicast in MPLS/BGP IP VPNs</xref></li>
+      <li><xref target="RFC6793">BGP Support for Four-Octet Autonomous System (AS) Number Space</xref></li>
+      <li><xref target="RFC7911">Advertisement of Multiple Paths in BGP </xref></li>
+      <li><xref target="RFC8092">BGP Large Communities Attributes</xref></li>
+      <li><xref target="RFC8177">YANG Key Chain</xref></li>
+      <li><xref target="RFC8277">Carrying Label Information in BGP-4 </xref></li>
+      <li><xref target="RFC9067">A YANG Data Model for Routing Policy</xref></li>
+      <li><xref target="RFC9314">YANG Data Model for Bidirectional Forward Detection</xref></li>
+      <li><xref target="RFC9293">Transmission Control Protocol</xref></li>
+      <li><xref target="I-D.ietf-tcpm-yang-tcp">YANG Model for Transmission Control Protocol (TCP) Configuration</xref></li>
+      </ul></t>
 
       <section title="Modules and submodules for base items">
 	<section title="ietf-bgp module">

--- a/draft/draft-ietf-idr-bgp-model.xml
+++ b/draft/draft-ietf-idr-bgp-model.xml
@@ -625,6 +625,9 @@ reference: RFC XXXX
 
       <t>The main module, ietf-bgp.yang, includes the following submodules:
       <ul>
+          <li>ietf-bgp-capabilities - defines the groupings that are common
+          to the BGP Capabilities feature.</li>
+
           <li>ietf-bgp-common - defines the groupings that are common across
           more than one context (where contexts are neighbor, group,
           global).</li>
@@ -703,6 +706,18 @@ INSERT_TEXT_FROM_FILE(../bin/ietf-bgp@YYYY-MM-DD.yang)
           </figure>
 	</t>
 	</section>
+	<section title = "ietf-bgp-capabilities submodule">
+	  <t>
+	  <figure>
+            <artwork><![CDATA[
+<CODE BEGINS> file "ietf-bgp-capabilities@YYYY-MM-DD.yang"
+INSERT_TEXT_FROM_FILE(../bin/submodules/ietf-bgp-capabilities@YYYY-MM-DD.yang)
+<CODE ENDS>
+
+        ]]></artwork>
+          </figure>
+	  </t>
+	</section>
 	<section title = "ietf-bgp-common submodule">
 	  <t>
 	  <figure>
@@ -710,7 +725,7 @@ INSERT_TEXT_FROM_FILE(../bin/ietf-bgp@YYYY-MM-DD.yang)
 <CODE BEGINS> file "ietf-bgp-common@YYYY-MM-DD.yang"
 INSERT_TEXT_FROM_FILE(../bin/submodules/ietf-bgp-common@YYYY-MM-DD.yang)
 <CODE ENDS>
- 
+
         ]]></artwork>
           </figure>
 	  </t>

--- a/src/yang/ietf-bgp-capabilities.yang
+++ b/src/yang/ietf-bgp-capabilities.yang
@@ -1,0 +1,339 @@
+submodule ietf-bgp-capabilities {
+  yang-version 1.1;
+  belongs-to ietf-bgp {
+    prefix bgp;
+  }
+
+  import iana-bgp-types {
+    prefix bt;
+    reference
+      "RFC XXXX: BGP Model for Service Provider Network.";
+  }
+  import iana-routing-types {
+    prefix iana-rt-types;
+  }
+  import ietf-inet-types {
+    prefix inet;
+    reference
+      "RFC 6991: Common YANG Data Types.";
+  }
+
+  organization
+    "IETF IDR Working Group";
+  contact
+    "WG Web:   <http://tools.ietf.org/wg/idr>
+     WG List:  <idr@ietf.org>
+
+     Authors: Mahesh Jethanandani (mjethanandani at gmail.com),
+              Keyur Patel (keyur at arrcus.com),
+              Susan Hares (shares at ndzh.com,
+              Jeffrey Haas (jhaas at juniper.net).";
+
+  description
+    "This sub-module contains groupings that used for BGP 
+     Capabilities within the BGP module.
+
+     Copyright (c) 2023 IETF Trust and the persons identified as
+     authors of the code. All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject to
+     the license terms contained in, the Revised BSD License set
+     forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (https://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC XXXX
+     (https://www.rfc-editor.org/info/rfcXXXX); see the RFC itself
+     for full legal notices.
+
+     The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL', 'SHALL
+     NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED', 'NOT RECOMMENDED',
+     'MAY', and 'OPTIONAL' in this document are to be interpreted as
+     described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
+     they appear in all capitals, as shown here.";
+
+  revision YYYY-MM-DD {
+    description
+      "Initial Version";
+    reference
+      "RFC XXXX, BGP Model for Service Provider Network.";
+  }
+
+  grouping bgp-capabilities-common {
+    description
+      "BGP Capabilities that are used commonly in by the
+       advertised-capabilities and received-capabilities lists in the
+       bgp-capabilities grouping.";
+
+    leaf code {
+      type uint8;
+      description
+        "BGP Capability Code";
+      reference
+        "RFC 5492: Capabilities Advertisement with BGP-4, Section
+         4."; }
+    leaf index {
+      type uint8;
+      description
+        "Multiple BGP Capabilities with a given Capability Code may
+         be advertised in a BGP OPEN message.  This index permits
+         multiple such Capabilities to be represented in the YANG
+         model.  It is RECOMMENDED that this index start at one (1)
+         and increase by one for each additional instance of the
+         Capability.";
+      reference
+        "RFC 5492: Capabilities Advertisement with BGP-4, Section
+         4."; }
+    leaf name {
+      type identityref {
+        base bt:bgp-capability;
+      }
+      description
+        "When known, name carries the bgp-capability identity for the
+         AFI/SAFI combination as used in the BGP YANG modules.";
+    }
+
+    container value {
+      description
+        "Some BGP Capabilities carry a Capability-specific Capability
+         Value.";
+      reference
+        "RFC 5492: Capabilities Advertisement with BGP-4, Section
+         4.";
+
+      container mpbgp {
+        when "../../name = 'bt:mp-bgp'";
+        description
+          "Multi-Protocol BGP-specific values.";
+        reference
+          "RFC 4760: Multiprotocol Extensions for BGP-4, Section 8.";
+
+        leaf afi {
+          type iana-rt-types:address-family;
+          description
+           "Address Family Identifier carried in the Multiprotocol
+            Extensions Capability.";
+          reference
+            "RFC 4760: Multiprotocol Extensions for BGP-4, Section
+             8.";
+        }
+        leaf safi {
+          type iana-rt-types:bgp-safi;
+          description
+           "Subsequent Address Family Identifier carried in the
+            Multiprotocol Extensions Capability.";
+          reference
+            "RFC 4760: Multiprotocol Extensions for BGP-4, Section
+             8.";
+        }
+        leaf name {
+          type identityref {
+            base bt:afi-safi-type;
+          }
+          description
+            "When known, name carries the BGP AFI-SAFI identity for
+             the AFI/SAFI combination as used in the BGP YANG
+             modules.";
+        }
+      }
+
+      container graceful-restart {
+        when "../../name = 'bt:graceful-restart'";
+        description
+          "BGP Graceful Restart-specific values.";
+        reference
+          "RFC 4724: Graceful Restart Mechanism for BGP.";
+
+        leaf flags {
+          type bits {
+            /* XXX JMH - how do we show unknown bits? */
+            bit restart {
+              position 0;
+              description
+                "";
+            }
+          }
+          description
+            "Restart Flags advertised by the Graceful Restart
+             Capability";
+          reference
+            "RFC 4724: Graceful Restart Mechanism for BGP, Section
+            3.";
+        }
+
+        leaf restart-time {
+          /* XXX JMH - create new ranged type. */
+          type uint16 {
+            range "0..4096";
+          }
+          units "seconds";
+          description
+            "The period of time (advertised by the peer) that the
+             peer expects a restart of a BGP session to take.";
+          reference
+            "RFC 4724: Graceful Restart Mechanism for BGP, Section
+             3.";
+        }
+
+        list afi-safis {
+          description
+            "List of AFI/SAFIs advertised by the BGP Graceful Restart
+             Capability and their AFI/SAFI-specific Flags.";
+          leaf afi {
+            type iana-rt-types:address-family;
+            description
+              "Address Family advertised in the BGP Graceful Restart
+               Capability.";
+            reference
+              "RFC 4724: Graceful Restart Mechanism for BGP, Section
+               3.";
+          }
+          leaf safi {
+            type iana-rt-types:bgp-safi;
+            description
+              "Subsequent Address Family advertised in the BGP
+               Graceful Restart Capability.";
+            reference
+              "RFC 4724: Graceful Restart Mechanism for BGP, Section
+               3.";
+          }
+          leaf afi-safi-flags {
+            /* XXX JMH - refactor */
+            type bits {
+              /* XXX JMH - how do we show unknown bits? */
+              bit forwarding-preserved {
+                position 0;
+                description
+                  "";
+              }
+            }
+            description
+              "Flags for Address Family advertised per-AFI/SAFI in
+               the BGP Graceful Restart Capability.";
+            reference
+              "RFC 4724: Graceful Restart Mechanism for BGP, Section
+               3.";
+          }
+        }
+      }
+
+      container asn32 {
+        when "../../name = 'bt:asn32'";
+        description
+          "Four-byte AS Number-specific values.";
+        reference
+          "RFC 6793: BGP Support for Four-Octet Autonomous System
+           (AS) Number Space, Section 3.";
+
+        leaf as {
+          type inet:as-number;
+          description
+            "Four-byte AS Number carried by the Support for 4-octet
+             AS number capability.";
+          reference
+            "RFC 6793: BGP Support for Four-Octet Autonomous System
+             (AS) Number Space, Section 3.";
+        }
+      }
+
+      container add-paths {
+        when "../../name = 'bt:add-paths'";
+        description
+          "BGP add-paths-specific values.";
+        reference
+          "RFC 7911: Advertisement of Multiple Paths in BGP.";
+
+        list afi-safis {
+          description
+            "List of AFI/SAFIs advertised by the BGP ADD-PATH
+             Capability and their AFI/SAFI-specific mode.";
+          leaf afi {
+            type iana-rt-types:address-family;
+            description
+              "Address Family Identifier for an instance of the BGP
+               ADD-PATH Capability.";
+            reference
+              "RFC 7911: Advertisement of Multiple Paths in BGP,
+               Section 4.";
+          }
+          leaf safi {
+            type iana-rt-types:bgp-safi;
+            description
+              "Subsequent Address Family Identifier for an instance
+               of the BGP ADD-PATH Capability.";
+            reference
+              "RFC 7911: Advertisement of Multiple Paths in BGP,
+               Section 4.";
+          }
+          leaf mode {
+            type enumeration {
+              enum receive {
+                value 1;
+                description "";
+              }
+              enum send {
+                value 2;
+                description "";
+              }
+              enum receive-send {
+                value 3;
+                description "";
+              }
+            }
+            description
+              "Send/Receive value for a per-AFI/SAFI instance of the
+               ADD-PATH Capability.";
+            reference
+              "RFC 7911: Advertisement of Multiple Paths in BGP,
+               Section 4.";
+          }
+        }
+      }
+    }
+  }
+
+  grouping bgp-capabilities {
+    description
+      "Structural grouping used to include BGP Capabiliites for BGP
+       neghbors.";
+
+    container capabilities {
+      config false;
+      description
+        "BGP Capabilities per-neighbor.";
+      reference
+        "RFC 5492: Capabilities Advertisement with BGP-4.";
+      
+      list advertised-capabilities {
+        key "code index";
+        description
+          "List of advertised BGP capabilities, per-peer.
+           Identified by the Capability Code and an index.  The
+           index covers the case where the same BGP Capability
+           may be advertised more than once.";
+
+        uses bgp-capabilities-common;
+      }
+
+      list received-capabilities {
+        key "code index";
+        description
+          "List of received BGP capabilities, per-peer.
+           Identified by the Capability Code and an index.  The
+           index covers the case where the same BGP Capability
+           may be advertised more than once.";
+
+        uses bgp-capabilities-common;
+      }
+
+      leaf-list negotiated-capabilities {
+        type identityref {
+          base bt:bgp-capability;
+        }
+        description
+          "Negotiated BGP capabilities.";
+      }
+    }
+  }
+}

--- a/src/yang/ietf-bgp-common.yang
+++ b/src/yang/ietf-bgp-common.yang
@@ -326,7 +326,6 @@ submodule ietf-bgp-common {
          rather than initiating sessions from the local router.";
     }
 
-    /* XXX JMH - local address and bfd are repeated due to this in neighbors? */
     leaf local-address {
       type union {
         type inet:ip-address;

--- a/src/yang/ietf-bgp-common.yang
+++ b/src/yang/ietf-bgp-common.yang
@@ -326,6 +326,7 @@ submodule ietf-bgp-common {
          rather than initiating sessions from the local router.";
     }
 
+    /* XXX JMH - local address and bfd are repeated due to this in neighbors? */
     leaf local-address {
       type union {
         type inet:ip-address;

--- a/src/yang/ietf-bgp-policy.yang
+++ b/src/yang/ietf-bgp-policy.yang
@@ -251,8 +251,8 @@ module ietf-bgp-policy {
             type string;
             description
               "AS path regular expression -- list of ASes in the
-               set. If any of the regular expression in the lists
-               is matched, the as-path-set is considered matched.";
+               set. If any of the regular expressions in the lists
+               are matched, the as-path-set is considered matched.";
           }
         }
       }

--- a/src/yang/ietf-bgp-policy.yang
+++ b/src/yang/ietf-bgp-policy.yang
@@ -200,7 +200,7 @@ module ietf-bgp-policy {
           }
           leaf-list member {
             type union {
-	      type bt:bgp-ext-community-type;
+              type bt:bgp-ext-community-type;
               type bt:bgp-community-regexp-type;
             }
             description

--- a/src/yang/ietf-bgp-rib-attributes.yang
+++ b/src/yang/ietf-bgp-rib-attributes.yang
@@ -58,7 +58,7 @@ submodule ietf-bgp-rib-attributes {
       "RFC XXXX: BGP YANG Model for Service Provider Network";
   }
 
-  grouping bgp-as-path-attr {
+  grouping bgp-as-path-segment {
     description
       "Data for representing BGP AS-PATH attribute";
 
@@ -73,20 +73,6 @@ submodule ietf-bgp-rib-attributes {
       type inet:as-number;
       description
         "List of the AS numbers in the AS-PATH segment";
-    }
-  }
-
-  grouping bgp-community-attr-state {
-    description
-      "Common definition of BGP community attributes";
-    leaf-list community {
-      type union {
-        type bt:bgp-well-known-community-type;
-        type bt:bgp-std-community-type;
-      }
-      description
-        "List of standard or well-known BGP community
-         attributes.";
     }
   }
 
@@ -142,6 +128,8 @@ submodule ietf-bgp-rib-attributes {
             "RFC 4271 - A Border Gateway Protocol 4 (BGP-4)";
         }
 
+        /* XXX JMH - perhaps this should be excluded since it's
+         * normally calculated? */
         leaf extended {
           type boolean;
           description
@@ -206,6 +194,20 @@ submodule ietf-bgp-rib-attributes {
          used, i.e., the capability has been negotiated.";
       reference
         "RFC 7911: Advertisement of Multiple Paths in BGP";
+    }
+  }
+
+  grouping bgp-community-attr-state {
+    description
+      "Common definition of BGP community attributes";
+    leaf-list community {
+      type union {
+        type bt:bgp-well-known-community-type;
+        type bt:bgp-std-community-type;
+      }
+      description
+        "List of standard or well-known BGP community
+         attributes.";
     }
   }
 

--- a/src/yang/ietf-bgp-rib-attributes.yang
+++ b/src/yang/ietf-bgp-rib-attributes.yang
@@ -60,7 +60,7 @@ submodule ietf-bgp-rib-attributes {
 
   grouping bgp-as-path-segment {
     description
-      "Data for representing BGP AS-PATH attribute";
+      "Data for representing BGP AS-PATH segment";
 
     leaf type {
       type identityref {

--- a/src/yang/ietf-bgp-rib-attributes.yang
+++ b/src/yang/ietf-bgp-rib-attributes.yang
@@ -128,8 +128,6 @@ submodule ietf-bgp-rib-attributes {
             "RFC 4271 - A Border Gateway Protocol 4 (BGP-4)";
         }
 
-        /* XXX JMH - perhaps this should be excluded since it's
-         * normally calculated? */
         leaf extended {
           type boolean;
           description

--- a/src/yang/ietf-bgp-rib-tables.yang
+++ b/src/yang/ietf-bgp-rib-tables.yang
@@ -106,12 +106,12 @@ submodule ietf-bgp-rib-tables {
   grouping bgp-adj-rib-in-post-route-annotations-state {
     description
       "Data definitions for information attached to routes in the
-       Adj-RIB-in post-policy table";
+       Adj-RIB-In post-policy table";
     leaf best-path {
       type boolean;
       description
         "Current path was selected as the best path. Best path
-         should indicate that the route is present in BGP LOC-RIB.";
+         should indicate that the route is present in BGP Loc-RIB.";
     }
   }
 
@@ -163,12 +163,21 @@ submodule ietf-bgp-rib-tables {
         "Reference to the extended community attribute for the
          route.";
     }
+    leaf large-community-index {
+      type leafref {
+        path "../../../../../../../../../large-communities/"
+           + "large-community/index";
+      }
+      description
+        "Reference to the large community attribute for the
+         route.";
+    }
   }
 
   grouping bgp-loc-rib-common-attr-refs {
     description
       "Definitions of common references to attribute sets for
-       multiple AFI-SAFIs for LOC-RIB tables.";
+       multiple AFI-SAFIs for Loc-RIB tables.";
     leaf attr-index {
       type leafref {
         path "../../../../../../../attr-sets/attr-set/"
@@ -195,12 +204,21 @@ submodule ietf-bgp-rib-tables {
         "Reference to the extended community attribute for the
          route.";
     }
+    leaf large-community-index {
+      type leafref {
+        path "../../../../../../../large-communities/"
+           + "large-community/index";
+      }
+      description
+        "Reference to the large community attribute for the
+         route.";
+    }
   }
 
   grouping bgp-loc-rib-common-keys {
     description
       "Common references used in keys for IPv4 and IPv6
-       LOC-RIB entries.";
+       Loc-RIB entries.";
     leaf origin {
       type union {
         type inet:ip-address;
@@ -260,7 +278,7 @@ submodule ietf-bgp-rib-tables {
 
   grouping ipv4-adj-rib-common {
     description
-      "Common structural grouping for each IPv4 adj-RIB table.";
+      "Common structural grouping for each IPv4 Adj-RIB table.";
     container routes {
       config false;
       description
@@ -271,7 +289,7 @@ submodule ietf-bgp-rib-tables {
         description
           "List of routes in the table, keyed by a combination of
            the route prefix and path-id to distinguish multiple
-           routes received from a neighbor for the same prefix,
+           routes received from a neighbor for the same prefix;
            e.g., when BGP add-paths is enabled.";
         leaf prefix {
           type inet:ipv4-prefix;
@@ -289,7 +307,7 @@ submodule ietf-bgp-rib-tables {
 
   grouping ipv4-adj-rib-in-post {
     description
-      "Common structural grouping for the IPv4 adj-rib-in
+      "Common structural grouping for the IPv4 Adj-RIB-In
        post-policy table.";
     container routes {
       config false;
@@ -301,7 +319,7 @@ submodule ietf-bgp-rib-tables {
         description
           "List of routes in the table, keyed by a combination of
            the route prefix and path-id to distinguish multiple
-           routes received from a neighbor for the same prefix,
+           routes received from a neighbor for the same prefix;
            e.g., when BGP add-paths is enabled.";
         leaf prefix {
           type inet:ipv4-prefix;
@@ -320,7 +338,7 @@ submodule ietf-bgp-rib-tables {
 
   grouping ipv6-adj-rib-common {
     description
-      "Common structural grouping for each IPv6 adj-RIB table.";
+      "Common structural grouping for each IPv6 Adj-RIB table.";
     container routes {
       config false;
       description
@@ -346,7 +364,7 @@ submodule ietf-bgp-rib-tables {
 
   grouping ipv6-adj-rib-in-post {
     description
-      "Common structural grouping for the IPv6 adj-rib-in
+      "Common structural grouping for the IPv6 Adj-RIB-In
        post-policy table.";
     container routes {
       config false;

--- a/src/yang/ietf-bgp-rib.yang
+++ b/src/yang/ietf-bgp-rib.yang
@@ -45,8 +45,8 @@ submodule ietf-bgp-rib {
               Jeffrey Haas (jhaas at juniper dot net).";
 
   description
-    "Defines a submodule for representing BGP Routing Information Base
-     (RIB) contents.  The submodule supports 5 logical RIBs per
+    "Defines a submodule for representing BGP Routing Information
+     Base (RIB) contents.  The submodule supports 5 logical RIBs per
      address family:
 
      loc-rib: This is the main BGP routing table for the local
@@ -261,8 +261,6 @@ submodule ietf-bgp-rib {
            subsumed by it.";
         reference
           "RFC 4271: Section 5.1.6.";
-      /* XXX JMH - the deprecate-as-set-confed-set draft may provide
-       * additional inputs for references. */
       }
       leaf originator-id {
         type yang:dotted-quad;
@@ -293,8 +291,6 @@ submodule ietf-bgp-rib {
     }
   }
 
-  /* XXX JMH - this is a singleton use right now.  collapse into
-   * attr-sets? */
   grouping attr-set {
     description
       "A grouping for all path attributes.";

--- a/src/yang/ietf-bgp-rib.yang
+++ b/src/yang/ietf-bgp-rib.yang
@@ -28,8 +28,8 @@ submodule ietf-bgp-rib {
 
   // groupings of attributes in three categories:
   //  - shared across multiple routes
-  //  - common to LOC-RIB and Adj-RIB, but not shared across routes
-  //  - specific to LOC-RIB or Adj-RIB
+  //  - common to Loc-RIB and Adj-RIB, but not shared across routes
+  //  - specific to Loc-RIB or Adj-RIB
   // groupings of annotations for each route or table
   include ietf-bgp-rib-attributes;
 
@@ -45,24 +45,24 @@ submodule ietf-bgp-rib {
               Jeffrey Haas (jhaas at juniper dot net).";
 
   description
-    "Defines a submodule for representing BGP routing table (RIB)
-     contents.  The submodule supports 5 logical RIBs per address
-     family:
+    "Defines a submodule for representing BGP Routing Information Base
+     (RIB) contents.  The submodule supports 5 logical RIBs per
+     address family:
 
      loc-rib: This is the main BGP routing table for the local
      routing instance, containing best-path selections for each
      prefix. The loc-rib table may contain multiple routes for a
      given prefix, with an attribute to indicate which was selected
      as the best path.  Note that multiple paths may be used or
-     advertised even if only one path is marked as best, e.g., when
+     advertised even if only one path is marked as best; e.g., when
      using BGP add-paths.  An implementation may choose to mark
      multiple paths in the RIB as best path by setting the flag to
      true for multiple entries.
 
-     adj-rib-in-pre: This is a per-neighbor table containing the NLRI
-     updates received from the neighbor before any local input policy
-     rules or filters have been applied.  This can be considered the
-     'raw' updates from a given neighbor.
+     adj-rib-in-pre: This is a per-neighbor table containing the BGP
+     routes received from the neighbor before any local input policy
+     rules has been applied.  This can be considered the 'raw' routes
+     from a given neighbor.
 
      adj-rib-in-post: This is a per-neighbor table containing the
      routes received from the neighbor that are eligible for
@@ -106,7 +106,7 @@ submodule ietf-bgp-rib {
 
   grouping attr-set-attributes {
     description
-      "A grouping for all attribute set parameters.";
+      "A grouping for all BGP Path Attribute set parameters.";
 
     container attributes {
       description
@@ -117,23 +117,40 @@ submodule ietf-bgp-rib {
         description
           "BGP attribute defining the origin of the path
            information.";
-      }
-      leaf atomic-aggregate {
-        type boolean;
-        description
-          "BGP attribute indicating that the prefix is an atomic
-           aggregate; i.e., the peer selected is a less specific
-           route without selecting a more specific route that is
-           subsumed by it.";
         reference
-          "RFC 4271: Section 5.1.6.";
+          "RFC 4271: Section 5.1.1.";
+      }
+      container as-path {
+        description
+          "Enclosing container for the list of AS path segments.
+
+           In the Adj-RIB-In or Adj-RIB-Out, this list should show
+           the received or sent AS_PATH, respectively.  For
+           example, if the local router is not 4-byte capable, this
+           value should consist of 2-octet ASNs or the AS_TRANS
+           (AS 23456) values received or sent in BGP updates.
+
+           In the Loc-RIB, this list should reflect the effective
+           AS path for the route, e.g., a 4-octet value if the
+           local router is 4-octet capable.";
+        reference
+          "RFC 4271 - A Border Gateway Protocol 4 (BGP-4)
+           RFC 6793 - BGP Support for Four-octet AS Number Space
+           RFC 5065 - Autonomous System Confederations for BGP";
+        list segment {
+          config false;
+          uses bgp-as-path-segment;
+          description
+            "List of AS PATH segments";
+        }
       }
       leaf next-hop {
         type inet:ip-address;
         description
           "BGP next hop attribute defining the IP address of the
            router that should be used as the next hop to the
-           destination.";
+           destination.  Used when the BGP routes' nexthop for that
+           AFI/SAFI can be represented as an IPv4/IPv6 address.";
         reference
           "RFC 4271: Section 5.1.3.";
       }
@@ -165,31 +182,23 @@ submodule ietf-bgp-rib {
         reference
           "RFC 4271: Section 5.1.5.";
       }
-      leaf originator-id {
-        type yang:dotted-quad;
+      container as4-path {
         description
-          "BGP attribute that provides the id as an IPv4 address
-           of the originator of the announcement.";
+          "This is the path encoded with 4-octet
+           AS numbers in the optional transitive AS4_PATH attribute.
+           This value is populated with the received or sent
+           attribute in Adj-RIB-In or Adj-RIB-Out, respectively.
+           It should not be populated in Loc-RIB since the Loc-RIB
+           is expected to store the effective AS-Path in the
+           as-path leaf regardless of being 4-octet or 2-octet.";
         reference
-          "RFC 4456 - BGP Route Reflection: An Alternative to Full
-           Mesh Internal BGP (IBGP)";
-      }
-      leaf-list cluster-list {
-        type yang:dotted-quad;
-        description
-          "Represents the reflection path that the route has
-           passed.";
-        reference
-          "RFC 4456 - BGP Route Reflection: An Alternative to Full
-           Mesh Internal BGP (IBGP)";
-      }
-      leaf aigp-metric {
-        type uint64;
-        description
-          "BGP path attribute representing the accumulated IGP
-           metric for the path";
-        reference
-          "RFC 7311 - The Accumulated IGP Metric Attribute for BGP";
+          "RFC 6793 - BGP Support for Four-octet AS Number Space";
+        list segment {
+          config false;
+          uses bgp-as-path-segment;
+          description
+            "List of AS PATH segments";
+        }
       }
       container aggregator {
         config false;
@@ -243,51 +252,49 @@ submodule ietf-bgp-rib {
              aggregation.";
         }
       }
-      container as-path {
+      leaf atomic-aggregate {
+        type boolean;
         description
-          "Enclosing container for the list of AS path segments.
-
-           In the Adj-RIB-In or Adj-RIB-Out, this list should show
-           the received or sent AS_PATH, respectively.  For
-           example, if the local router is not 4-byte capable, this
-           value should consist of 2-octet ASNs or the AS_TRANS
-           (AS 23456) values received or sent in route updates.
-
-           In the Loc-RIB, this list should reflect the effective
-           AS path for the route, e.g., a 4-octet value if the
-           local router is 4-octet capable.";
+          "BGP attribute indicating that the prefix is an atomic
+           aggregate; i.e., the peer selected is a less specific
+           route without selecting a more specific route that is
+           subsumed by it.";
         reference
-          "RFC 4271 - A Border Gateway Protocol 4 (BGP-4)
-           RFC 6793 - BGP Support for Four-octet AS Number Space
-           RFC 5065 - Autonomous System Confederations for BGP";
-        list segment {
-          config false;
-          uses bgp-as-path-attr;
-          description
-            "List of AS PATH segments";
-        }
+          "RFC 4271: Section 5.1.6.";
+      /* XXX JMH - the deprecate-as-set-confed-set draft may provide
+       * additional inputs for references. */
       }
-      container as4-path {
+      leaf originator-id {
+        type yang:dotted-quad;
         description
-          "This is the path encoded with 4-octet
-           AS numbers in the optional transitive AS4_PATH attribute.
-           This value is populated with the received or sent
-           attribute in Adj-RIB-In or Adj-RIB-Out, respectively.
-           It should not be populated in Loc-RIB since the Loc-RIB
-           is expected to store the effective AS-Path in the
-           as-path leaf regardless of being 4-octet or 2-octet.";
+          "BGP attribute that provides the id as an IPv4 address
+           of the originator of the announcement.";
         reference
-          "RFC 6793 - BGP Support for Four-octet AS Number Space";
-        list segment {
-          config false;
-          uses bgp-as-path-attr;
-          description
-            "List of AS PATH segments";
-        }
+          "RFC 4456 - BGP Route Reflection: An Alternative to Full
+           Mesh Internal BGP (IBGP)";
+      }
+      leaf-list cluster-list {
+        type yang:dotted-quad;
+        description
+          "Represents the reflection path that the route has
+           passed.";
+        reference
+          "RFC 4456 - BGP Route Reflection: An Alternative to Full
+           Mesh Internal BGP (IBGP)";
+      }
+      leaf aigp-metric {
+        type uint64;
+        description
+          "BGP path attribute representing the accumulated IGP
+           metric for the path";
+        reference
+          "RFC 7311 - The Accumulated IGP Metric Attribute for BGP";
       }
     }
   }
 
+  /* XXX JMH - this is a singleton use right now.  collapse into
+   * attr-sets? */
   grouping attr-set {
     description
       "A grouping for all path attributes.";
@@ -323,6 +330,7 @@ submodule ietf-bgp-rib {
   grouping rib {
     description
       "Grouping for rib.";
+
     container rib {
       config false;
       uses attr-sets;
@@ -417,7 +425,7 @@ submodule ietf-bgp-rib {
             container loc-rib {
               config false;
               description
-                "Container for the IPv4 BGP LOC-RIB data.";
+                "Container for the IPv4 Unicast BGP Loc-RIB data.";
               container routes {
                 description
                   "Enclosing container for list of routes in the
@@ -463,10 +471,10 @@ submodule ietf-bgp-rib {
                 }
                 container adj-rib-in-pre {
                   description
-                    "Per-neighbor table containing the NLRI updates
+                    "Per-neighbor table containing the BGP routes
                      received from the neighbor before any local
                      input policy rules or filters have been applied.
-                     This can be considered the 'raw' updates from
+                     This can be considered the 'raw' routes from
                      the neighbor.";
                   uses ipv4-adj-rib-common;
                   uses clear-routes {
@@ -474,7 +482,7 @@ submodule ietf-bgp-rib {
                       "Clears the adj-rib-in state for the containing
                        neighbor. Subsequently, implementations might
                        issue a 'route refresh' if 'route refresh' has
-                       been negotiatited, or reset the session. ";
+                       been negotiated, or reset the session. ";
                   }
                 }
                 container adj-rib-in-post {
@@ -489,7 +497,7 @@ submodule ietf-bgp-rib {
                       "Clears the adj-rib-in state for the containing
                        neighbor. Subsequently, implementations might
                        issue a 'route refresh' if 'route refresh' has
-                       been negotiatited, or reset the session. ";
+                       been negotiated, or reset the session. ";
                   }
                 }
                 container adj-rib-out-pre {
@@ -536,7 +544,7 @@ submodule ietf-bgp-rib {
             container loc-rib {
               config false;
               description
-                "Container for the IPv6 BGP LOC-RIB data.";
+                "Container for the IPv6 BGP Loc-RIB data.";
               container routes {
                 description
                   "Enclosing container for list of routes in the
@@ -582,10 +590,10 @@ submodule ietf-bgp-rib {
                 }
                 container adj-rib-in-pre {
                   description
-                    "Per-neighbor table containing the NLRI updates
+                    "Per-neighbor table containing the BGP routes
                      received from the neighbor before any local
                      input policy rules or filters have been applied.
-                     This can be considered the 'raw' updates from
+                     This can be considered the 'raw' routes from
                      the neighbor.";
                   uses ipv6-adj-rib-common;
                   uses clear-routes {
@@ -593,7 +601,7 @@ submodule ietf-bgp-rib {
                       "Clears the adj-rib-in state for the containing
                        neighbor. Subsequently, implementations might
                        issue a 'route refresh' if 'route refresh' has
-                       been negotiatited, or reset the session. ";
+                       been negotiated, or reset the session. ";
                   }
                 }
                 container adj-rib-in-post {
@@ -608,7 +616,7 @@ submodule ietf-bgp-rib {
                       "Clears the adj-rib-in state for the containing
                        neighbor. Subsequently, implementations might
                        issue a 'route refresh' if 'route refresh' has
-                       been negotiatited, or reset the session. ";
+                       been negotiated, or reset the session. ";
                   }
                 }
                 container adj-rib-out-pre {

--- a/src/yang/ietf-bgp.yang
+++ b/src/yang/ietf-bgp.yang
@@ -16,7 +16,7 @@ module ietf-bgp {
   import ietf-routing-policy {
     prefix rt-pol;
     reference
-      "RFC ZZZZ, A YANG Data Model for Routing Policy Management.";
+      "RFC 9067, A YANG Data Model for Routing Policy.";
   }
   import ietf-interfaces {
     prefix if;
@@ -27,12 +27,13 @@ module ietf-bgp {
     prefix bt;
     reference
       "RFC XXXX, BGP YANG Model for Service Provider Network.";
+      /* XXX JMH Title? */
   }
   import ietf-bfd-types {
     prefix bfd-types;
     reference
-      "RFC 9314: YANG Data Model for Bidirectional Forward Detection
-       (BFD).";
+      "RFC 9314: YANG Data Model for Bidirectional Forwarding
+       Detection (BFD).";
   }
   import ietf-inet-types {
     prefix inet;
@@ -47,7 +48,7 @@ module ietf-bgp {
   import ietf-key-chain {
     prefix key-chain;
     reference
-      "RFC 8177: YANG Key Chain.";
+      "RFC 8177: YANG Data Model for Key Chains";
   }
   include ietf-bgp-common {
     revision-date YYYY-MM-DD;
@@ -396,7 +397,7 @@ module ietf-bgp {
               "The remote port for the TCP connection
                between the BGP peers.  Note that the
                objects local-addr, local-port, remote-addr, and
-               reemote-port provide the appropriate
+               remote-port provide the appropriate
                reference to the standard MIB TCP
                connection table.";
           }
@@ -444,7 +445,7 @@ module ietf-bgp {
                not initiate connections to the neighbor, and should
                not respond to TCP connections attempts from the
                neighbor. If the state of the BGP session is
-               ESTABLISHED at the time that this leaf is set to
+               Established at the time that this leaf is set to
                false, the BGP session should be ceased.
 
                A transition from 'false' to 'true' will cause
@@ -467,6 +468,7 @@ module ietf-bgp {
           }
 
           container secure-session {
+            /* XXX JMH - why is this constraint mandatory? alos, why not have the enable in this container? */
             when "../secure-session-enable = 'true'";
             description
               "Container for describing how a particular BGP session
@@ -588,9 +590,10 @@ module ietf-bgp {
 
                The BGP session uptime can be computed by clients as
                the difference between this value and the current time
-               in UTC (assuming the session is in the ESTABLISHED
+               in UTC (assuming the session is in the Established
                state, per the session-state leaf).";
           }
+          /* XXX JMH - we probably want a list of sent and received capabilities. */
           leaf-list negotiated-capabilities {
             type identityref {
               base bt:bgp-capability;
@@ -605,6 +608,7 @@ module ietf-bgp {
             description
               "The negotiated hold-time for the BGP session";
           }
+          /* XXX JMH - need better errors.  See also OC's model. */
           leaf last-error {
             type binary {
               length "2";
@@ -678,6 +682,7 @@ module ietf-bgp {
                 "RFC 4273: Definitions of Managed Objects for
                  BGP-4.";
             }
+            /* XXX JMH - what's the difference between peer-fsm-estabhslished-transitions and fsm-established-transitions? */
             leaf fsm-established-transitions {
               type yang:zero-based-counter32;
               description
@@ -832,6 +837,7 @@ module ietf-bgp {
               "IP address of the neighbor that went into established
                state.";
           }
+          /* XXX JMH - last error probably doesn't make sense here? */
           leaf last-error {
             type leafref {
               path "../../neighbor/last-error";
@@ -846,6 +852,7 @@ module ietf-bgp {
             reference
               "RFC 4271, Section 4.5.";
           }
+          /* XXX JMH - I think this notification type implies established?*/
           leaf session-state {
             type leafref {
               path "../../neighbor/session-state";
@@ -869,6 +876,7 @@ module ietf-bgp {
               "IP address of the neighbor that changed its state from
                established state.";
           }
+          /* XXX JMH - reevaluate based on other discussion. */
           leaf last-error {
             type leafref {
               path "../../neighbor/last-error";
@@ -883,6 +891,7 @@ module ietf-bgp {
             reference
               "RFC 4271, Section 4.5.";
           }
+          /* This lingers from RFC 4273 and might not be helpful? */
           leaf session-state {
             type leafref {
               path "../../neighbor/session-state";
@@ -950,7 +959,6 @@ module ietf-bgp {
               }
             }
 
-
             leaf clear-at {
               type yang:date-and-time;
               description
@@ -984,6 +992,7 @@ module ietf-bgp {
               "Name of the BGP peer-group";
           }
 
+          /* XXX JMH - can the secure session stuff be refactored from above? */
           leaf secure-session-enable {
             type boolean;
             default "false";
@@ -1050,6 +1059,7 @@ module ietf-bgp {
             }
           }
 
+          /* XXX JMH - refactor? */
           leaf ttl-security {
             if-feature "bt:ttl-security";
             type uint8;
@@ -1088,6 +1098,7 @@ module ietf-bgp {
         }
       }
 
+      /* XXX JMH - what implementation needs BFD config per interface for BGP? */
       container interfaces {
         list interface {
           key "name";

--- a/src/yang/ietf-bgp.yang
+++ b/src/yang/ietf-bgp.yang
@@ -27,7 +27,6 @@ module ietf-bgp {
     prefix bt;
     reference
       "RFC XXXX, BGP YANG Model for Service Provider Network.";
-      /* XXX JMH Title? */
   }
   import ietf-bfd-types {
     prefix bfd-types;
@@ -468,7 +467,6 @@ module ietf-bgp {
           }
 
           container secure-session {
-            /* XXX JMH - why is this constraint mandatory? alos, why not have the enable in this container? */
             when "../secure-session-enable = 'true'";
             description
               "Container for describing how a particular BGP session
@@ -593,7 +591,6 @@ module ietf-bgp {
                in UTC (assuming the session is in the Established
                state, per the session-state leaf).";
           }
-          /* XXX JMH - we probably want a list of sent and received capabilities. */
           leaf-list negotiated-capabilities {
             type identityref {
               base bt:bgp-capability;
@@ -608,7 +605,6 @@ module ietf-bgp {
             description
               "The negotiated hold-time for the BGP session";
           }
-          /* XXX JMH - need better errors.  See also OC's model. */
           leaf last-error {
             type binary {
               length "2";
@@ -682,7 +678,6 @@ module ietf-bgp {
                 "RFC 4273: Definitions of Managed Objects for
                  BGP-4.";
             }
-            /* XXX JMH - what's the difference between peer-fsm-estabhslished-transitions and fsm-established-transitions? */
             leaf fsm-established-transitions {
               type yang:zero-based-counter32;
               description
@@ -837,7 +832,6 @@ module ietf-bgp {
               "IP address of the neighbor that went into established
                state.";
           }
-          /* XXX JMH - last error probably doesn't make sense here? */
           leaf last-error {
             type leafref {
               path "../../neighbor/last-error";
@@ -852,7 +846,6 @@ module ietf-bgp {
             reference
               "RFC 4271, Section 4.5.";
           }
-          /* XXX JMH - I think this notification type implies established?*/
           leaf session-state {
             type leafref {
               path "../../neighbor/session-state";
@@ -876,7 +869,6 @@ module ietf-bgp {
               "IP address of the neighbor that changed its state from
                established state.";
           }
-          /* XXX JMH - reevaluate based on other discussion. */
           leaf last-error {
             type leafref {
               path "../../neighbor/last-error";
@@ -992,7 +984,6 @@ module ietf-bgp {
               "Name of the BGP peer-group";
           }
 
-          /* XXX JMH - can the secure session stuff be refactored from above? */
           leaf secure-session-enable {
             type boolean;
             default "false";
@@ -1059,7 +1050,6 @@ module ietf-bgp {
             }
           }
 
-          /* XXX JMH - refactor? */
           leaf ttl-security {
             if-feature "bt:ttl-security";
             type uint8;
@@ -1098,7 +1088,6 @@ module ietf-bgp {
         }
       }
 
-      /* XXX JMH - what implementation needs BFD config per interface for BGP? */
       container interfaces {
         list interface {
           key "name";

--- a/src/yang/ietf-bgp.yang
+++ b/src/yang/ietf-bgp.yang
@@ -49,6 +49,9 @@ module ietf-bgp {
     reference
       "RFC 8177: YANG Data Model for Key Chains";
   }
+  include ietf-bgp-capabilities {
+    revision-date YYYY-MM-DD;
+  }
   include ietf-bgp-common {
     revision-date YYYY-MM-DD;
   }
@@ -176,6 +179,7 @@ module ietf-bgp {
         type uint16 {
           range "0..4096";
         }
+        units "seconds";
         config false;
         description
           "The period of time (advertised by the peer) that the
@@ -591,14 +595,9 @@ module ietf-bgp {
                in UTC (assuming the session is in the Established
                state, per the session-state leaf).";
           }
-          leaf-list negotiated-capabilities {
-            type identityref {
-              base bt:bgp-capability;
-            }
-            config false;
-            description
-              "Negotiated BGP capabilities.";
-          }
+
+          uses bgp-capabilities;
+
           leaf negotiated-hold-time {
             type uint16;
             config false;


### PR DESCRIPTION
The OC-inherited model only showed "negotiated capabilities".  There's an operational need to be able to show the sent/received capabilities and their  capability-specific data.

Closes #248 