### PR TITLE
Issue #248 - Restructure BGP capability state.

### DIFF
--- a/draft/Makefile
+++ b/draft/Makefile
@@ -50,8 +50,9 @@ endif
 	-rm -f ../bin/submodules/*\@$(shell date +%Y)*.yang
 	-rm -f ../bin/submodules/*\@$(shell date +%Y)*-*-*.yang
 
-$(next).xml: $(draft).xml ../src/yang/ietf-bgp-common-multiprotocol.yang ../src/yang/ietf-bgp-common-structure.yang ../src/yang/ietf-bgp-common.yang ../src/yang/ietf-bgp-neighbor.yang ../src/yang/ietf-bgp-policy.yang ../src/yang/iana-bgp-types.yang ../src/yang/ietf-bgp.yang rib
+$(next).xml: $(draft).xml ../src/yang/ietf-bgp-capabilities.yang ../src/yang/ietf-bgp-common-multiprotocol.yang ../src/yang/ietf-bgp-common-structure.yang ../src/yang/ietf-bgp-common.yang ../src/yang/ietf-bgp-neighbor.yang ../src/yang/ietf-bgp-policy.yang ../src/yang/iana-bgp-types.yang ../src/yang/ietf-bgp.yang rib
 	sed -e"s/$(basename $<)-latest/$(basename $@)/" -e"s/YYYY-MM-DD/$(shell date +%Y-%m-%d)/" $< > $@
+	sed -e"s/YYYY-MM-DD/$(shell date +%Y-%m-%d)/" ../src/yang/ietf-bgp-capabilities.yang > ../bin/submodules/ietf-bgp-capabilities\@$(shell date +%Y-%m-%d).yang
 	sed -e"s/YYYY-MM-DD/$(shell date +%Y-%m-%d)/" ../src/yang/ietf-bgp-common-multiprotocol.yang > ../bin/submodules/ietf-bgp-common-multiprotocol\@$(shell date +%Y-%m-%d).yang
 	sed -e"s/YYYY-MM-DD/$(shell date +%Y-%m-%d)/" ../src/yang/ietf-bgp-common-structure.yang > ../bin/submodules/ietf-bgp-common-structure\@$(shell date +%Y-%m-%d).yang
 	sed -e"s/YYYY-MM-DD/$(shell date +%Y-%m-%d)/" ../src/yang/ietf-bgp-common.yang > ../bin/submodules/ietf-bgp-common\@$(shell date +%Y-%m-%d).yang

--- a/draft/draft-ietf-idr-bgp-model.xml
+++ b/draft/draft-ietf-idr-bgp-model.xml
@@ -625,6 +625,9 @@ reference: RFC XXXX
 
       <t>The main module, ietf-bgp.yang, includes the following submodules:
       <ul>
+          <li>ietf-bgp-capabilities - defines the groupings that are common
+          to the BGP Capabilities feature.</li>
+
           <li>ietf-bgp-common - defines the groupings that are common across
           more than one context (where contexts are neighbor, group,
           global).</li>
@@ -703,6 +706,18 @@ INSERT_TEXT_FROM_FILE(../bin/ietf-bgp@YYYY-MM-DD.yang)
           </figure>
 	</t>
 	</section>
+	<section title = "ietf-bgp-capabilities submodule">
+	  <t>
+	  <figure>
+            <artwork><![CDATA[
+<CODE BEGINS> file "ietf-bgp-capabilities@YYYY-MM-DD.yang"
+INSERT_TEXT_FROM_FILE(../bin/submodules/ietf-bgp-capabilities@YYYY-MM-DD.yang)
+<CODE ENDS>
+
+        ]]></artwork>
+          </figure>
+	  </t>
+	</section>
 	<section title = "ietf-bgp-common submodule">
 	  <t>
 	  <figure>
@@ -710,7 +725,7 @@ INSERT_TEXT_FROM_FILE(../bin/ietf-bgp@YYYY-MM-DD.yang)
 <CODE BEGINS> file "ietf-bgp-common@YYYY-MM-DD.yang"
 INSERT_TEXT_FROM_FILE(../bin/submodules/ietf-bgp-common@YYYY-MM-DD.yang)
 <CODE ENDS>
- 
+
         ]]></artwork>
           </figure>
 	  </t>

--- a/src/yang/iana-bgp-types.yang
+++ b/src/yang/iana-bgp-types.yang
@@ -623,4 +623,18 @@ module iana-bgp-types {
        option 1: 4-byte number
        option 2: IP address";
   }
+
+  typedef graceful-restart-time-type {
+    type uint16 {
+      range "0..4096";
+    }
+    units "seconds";
+    description
+      "This is the estimated time (in seconds) it will take for the
+       BGP session to be re-established after a restart.  This can be
+       used to speed up routing convergence by its peer in case that
+       the BGP speaker does not come back after a restart.";
+    reference
+       "RFC 4724: Graceful Restart Mechanism for BGP, Section 3.";
+  }
 }

--- a/src/yang/iana-bgp-types.yang
+++ b/src/yang/iana-bgp-types.yang
@@ -637,4 +637,69 @@ module iana-bgp-types {
     reference
        "RFC 4724: Graceful Restart Mechanism for BGP, Section 3.";
   }
+
+  typedef graceful-restart-flags {
+    type bits {
+      bit restart {
+        position 0;
+        description
+          "The most significant bit is defined as the Restart
+           State (R) bit, which can be used to avoid possible
+           deadlock caused by waiting for the End-of-RIB marker
+           when multiple BGP speakers peering with each other
+           restart.  When set (value 1), this bit indicates
+           that the BGP speaker has restarted, and its peer
+           MUST NOT wait for the End-of-RIB marker from the
+           speaker before advertising routing information to
+           the speaker.";
+        reference
+          "RFC 4724: Graceful Restart Mechanism for BGP,
+           Section 3.";
+      }
+      bit notification {
+        position 1;
+        description
+          "The second most significant bit is defined in [RFC 8538]
+           as the Graceful Notification ('N') bit.  It is used to
+           indicate Graceful Restart support for BGP NOTIFICATION
+           messages.  A BGP speaker indicates support for the
+           procedures in this document by advertising a Graceful
+           Restart Capability with its 'N' bit set (value 1).";
+        reference
+          "RFC 8538: Notification Message Support for BGP Graceful
+           Restart, Section 2.";
+      }
+    }
+    description
+      "Restart Flags bits as defined for BGP Graceful Restart and its
+       extensions.";
+    reference
+      "RFC 4724: Graceful Restart Mechanism for BGP,
+       RFC 8538: Notification Message Support for BGP Graceful
+       Restart.";
+  }
+
+  typedef graceful-restart-flags-for-afi {
+    type bits {
+      bit forwarding-preserved {
+        position 0;
+        description
+          "The most significant bit is defined as the
+           Forwarding State (F) bit, which can be used to
+           indicate whether the forwarding state for routes
+           that were advertised with the given AFI and SAFI
+           has indeed been preserved during the previous BGP
+           restart.  When set (value 1), the bit indicates
+           that the forwarding state has been preserved.";
+         reference
+           "RFC 4724: Graceful Restart Mechanism for BGP,
+            Section 3.";
+      }
+    }
+    description
+      "Flags for Address Family bits as defined for BGP Graceful
+       Restart and its extensions.";
+    reference
+      "RFC 4724: Graceful Restart Mechanism for BGP.";
+  }
 }

--- a/src/yang/ietf-bgp-capabilities.yang
+++ b/src/yang/ietf-bgp-capabilities.yang
@@ -153,30 +153,35 @@ submodule ietf-bgp-capabilities {
           "RFC 4724: Graceful Restart Mechanism for BGP.";
 
         leaf flags {
-          type bits {
-            bit restart {
-              position 0;
-              description
-                "The most significant bit is defined as the Restart
-                 State (R) bit, which can be used to avoid possible
-                 deadlock caused by waiting for the End-of-RIB marker
-                 when multiple BGP speakers peering with each other
-                 restart.  When set (value 1), this bit indicates
-                 that the BGP speaker has restarted, and its peer
-                 MUST NOT wait for the End-of-RIB marker from the
-                 speaker before advertising routing information to
-                 the speaker.";
-              reference
-                "RFC 4724: Graceful Restart Mechanism for BGP,
-                 Section 3.";
-            }
-          }
+          type bt:graceful-restart-flags;
           description
             "Restart Flags advertised by the Graceful Restart
              Capability";
           reference
             "RFC 4724: Graceful Restart Mechanism for BGP, Section
-            3.";
+             3.";
+        }
+
+        leaf unknown-flags {
+          type bits {
+            bit unknown-2 {
+              position 2;
+              description
+                "Bit 2 was received but is currently RESERVED.";
+            }
+            bit unknown-3 {
+              position 3;
+              description
+                "Bit 3 was received but is currently RESERVED.";
+            }
+          }
+          description
+            "When a bit is exchanged in the Graceful Restart Flags
+             field that is unknown to this module, their bit position
+             is rendered using the associated unknown bit.";
+          reference
+            "RFC 4724: Graceful Restart Mechanism for BGP, Section
+             3.";
         }
 
         leaf restart-time {
@@ -212,25 +217,57 @@ submodule ietf-bgp-capabilities {
                3.";
           }
           leaf afi-safi-flags {
-            type bits {
-              bit forwarding-preserved {
-                position 0;
-                description
-                  "The most significant bit is defined as the
-                   Forwarding State (F) bit, which can be used to
-                   indicate whether the forwarding state for routes
-                   that were advertised with the given AFI and SAFI
-                   has indeed been preserved during the previous BGP
-                   restart.  When set (value 1), the bit indicates
-                   that the forwarding state has been preserved.";
-                 reference
-                   "RFC 4724: Graceful Restart Mechanism for BGP,
-                    Section 3.";
-              }
-            }
+            type bt:graceful-restart-flags-for-afi;
             description
               "Flags for Address Family advertised per-AFI/SAFI in
                the BGP Graceful Restart Capability.";
+            reference
+              "RFC 4724: Graceful Restart Mechanism for BGP, Section
+               3.";
+          }
+          leaf afi-safi-unknown-flags {
+            type bits {
+              bit unknown-1 {
+                position 1;
+                description
+                  "Bit 1 was received but is currently RESERVED.";
+              }
+              bit unknown-2 {
+                position 2;
+                description
+                  "Bit 2 was received but is currently RESERVED.";
+              }
+              bit unknown-3 {
+                position 3;
+                description
+                  "Bit 3 was received but is currently RESERVED.";
+              }
+              bit unknown-4 {
+                position 4;
+                description
+                  "Bit 4 was received but is currently RESERVED.";
+              }
+              bit unknown-5 {
+                position 5;
+                description
+                  "Bit 5 was received but is currently RESERVED.";
+              }
+              bit unknown-6 {
+                position 6;
+                description
+                  "Bit 6 was received but is currently RESERVED.";
+              }
+              bit unknown-7 {
+                position 7;
+                description
+                  "Bit 7 was received but is currently RESERVED.";
+              }
+            }
+            description
+              "When a bit is exchanged in the Graceful Restart Flags
+               for Address Family field that is unknown to this
+               module, their bit position is rendered using the
+               associated unknown bit.";
             reference
               "RFC 4724: Graceful Restart Mechanism for BGP, Section
                3.";

--- a/src/yang/ietf-bgp-capabilities.yang
+++ b/src/yang/ietf-bgp-capabilities.yang
@@ -1,0 +1,339 @@
+submodule ietf-bgp-capabilities {
+  yang-version 1.1;
+  belongs-to ietf-bgp {
+    prefix bgp;
+  }
+
+  import iana-bgp-types {
+    prefix bt;
+    reference
+      "RFC XXXX: BGP Model for Service Provider Network.";
+  }
+  import iana-routing-types {
+    prefix iana-rt-types;
+  }
+  import ietf-inet-types {
+    prefix inet;
+    reference
+      "RFC 6991: Common YANG Data Types.";
+  }
+
+  organization
+    "IETF IDR Working Group";
+  contact
+    "WG Web:   <http://tools.ietf.org/wg/idr>
+     WG List:  <idr@ietf.org>
+
+     Authors: Mahesh Jethanandani (mjethanandani at gmail.com),
+              Keyur Patel (keyur at arrcus.com),
+              Susan Hares (shares at ndzh.com,
+              Jeffrey Haas (jhaas at juniper.net).";
+
+  description
+    "This sub-module contains groupings that used for BGP 
+     Capabilities within the BGP module.
+
+     Copyright (c) 2023 IETF Trust and the persons identified as
+     authors of the code. All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject to
+     the license terms contained in, the Revised BSD License set
+     forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (https://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC XXXX
+     (https://www.rfc-editor.org/info/rfcXXXX); see the RFC itself
+     for full legal notices.
+
+     The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL', 'SHALL
+     NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED', 'NOT RECOMMENDED',
+     'MAY', and 'OPTIONAL' in this document are to be interpreted as
+     described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
+     they appear in all capitals, as shown here.";
+
+  revision YYYY-MM-DD {
+    description
+      "Initial Version";
+    reference
+      "RFC XXXX, BGP Model for Service Provider Network.";
+  }
+
+  grouping bgp-capabilities-common {
+    description
+      "BGP Capabilities that are used commonly in by the
+       advertised-capabilities and received-capabilities lists in the
+       bgp-capabilities grouping.";
+
+    leaf code {
+      type uint8;
+      description
+        "BGP Capability Code";
+      reference
+        "RFC 5492: Capabilities Advertisement with BGP-4, Section
+         4."; }
+    leaf index {
+      type uint8;
+      description
+        "Multiple BGP Capabilities with a given Capability Code may
+         be advertised in a BGP OPEN message.  This index permits
+         multiple such Capabilities to be represented in the YANG
+         model.  It is RECOMMENDED that this index start at one (1)
+         and increase by one for each additional instance of the
+         Capability.";
+      reference
+        "RFC 5492: Capabilities Advertisement with BGP-4, Section
+         4."; }
+    leaf name {
+      type identityref {
+        base bt:bgp-capability;
+      }
+      description
+        "When known, name carries the bgp-capability identity for the
+         AFI/SAFI combination as used in the BGP YANG modules.";
+    }
+
+    container value {
+      description
+        "Some BGP Capabilities carry a Capability-specific Capability
+         Value.";
+      reference
+        "RFC 5492: Capabilities Advertisement with BGP-4, Section
+         4.";
+
+      container mpbgp {
+        when "../../name = 'bt:mp-bgp'";
+        description
+          "Multi-Protocol BGP-specific values.";
+        reference
+          "RFC 4760: Multiprotocol Extensions for BGP-4, Section 8.";
+
+        leaf afi {
+          type iana-rt-types:address-family;
+          description
+           "Address Family Identifier carried in the Multiprotocol
+            Extensions Capability.";
+          reference
+            "RFC 4760: Multiprotocol Extensions for BGP-4, Section
+             8.";
+        }
+        leaf safi {
+          type iana-rt-types:bgp-safi;
+          description
+           "Subsequent Address Family Identifier carried in the
+            Multiprotocol Extensions Capability.";
+          reference
+            "RFC 4760: Multiprotocol Extensions for BGP-4, Section
+             8.";
+        }
+        leaf name {
+          type identityref {
+            base bt:afi-safi-type;
+          }
+          description
+            "When known, name carries the BGP AFI-SAFI identity for
+             the AFI/SAFI combination as used in the BGP YANG
+             modules.";
+        }
+      }
+
+      container graceful-restart {
+        when "../../name = 'bt:graceful-restart'";
+        description
+          "BGP Graceful Restart-specific values.";
+        reference
+          "RFC 4724: Graceful Restart Mechanism for BGP.";
+
+        leaf flags {
+          type bits {
+            /* XXX JMH - how do we show unknown bits? */
+            bit restart {
+              position 0;
+              description
+                "";
+            }
+          }
+          description
+            "Restart Flags advertised by the Graceful Restart
+             Capability";
+          reference
+            "RFC 4724: Graceful Restart Mechanism for BGP, Section
+            3.";
+        }
+
+        leaf restart-time {
+          /* XXX JMH - create new ranged type. */
+          type uint16 {
+            range "0..4096";
+          }
+          units "seconds";
+          description
+            "The period of time (advertised by the peer) that the
+             peer expects a restart of a BGP session to take.";
+          reference
+            "RFC 4724: Graceful Restart Mechanism for BGP, Section
+             3.";
+        }
+
+        list afi-safis {
+          description
+            "List of AFI/SAFIs advertised by the BGP Graceful Restart
+             Capability and their AFI/SAFI-specific Flags.";
+          leaf afi {
+            type iana-rt-types:address-family;
+            description
+              "Address Family advertised in the BGP Graceful Restart
+               Capability.";
+            reference
+              "RFC 4724: Graceful Restart Mechanism for BGP, Section
+               3.";
+          }
+          leaf safi {
+            type iana-rt-types:bgp-safi;
+            description
+              "Subsequent Address Family advertised in the BGP
+               Graceful Restart Capability.";
+            reference
+              "RFC 4724: Graceful Restart Mechanism for BGP, Section
+               3.";
+          }
+          leaf afi-safi-flags {
+            /* XXX JMH - refactor */
+            type bits {
+              /* XXX JMH - how do we show unknown bits? */
+              bit forwarding-preserved {
+                position 0;
+                description
+                  "";
+              }
+            }
+            description
+              "Flags for Address Family advertised per-AFI/SAFI in
+               the BGP Graceful Restart Capability.";
+            reference
+              "RFC 4724: Graceful Restart Mechanism for BGP, Section
+               3.";
+          }
+        }
+      }
+
+      container asn32 {
+        when "../../name = 'bt:asn32'";
+        description
+          "Four-byte AS Number-specific values.";
+        reference
+          "RFC 6793: BGP Support for Four-Octet Autonomous System
+           (AS) Number Space, Section 3.";
+
+        leaf as {
+          type inet:as-number;
+          description
+            "Four-byte AS Number carried by the Support for 4-octet
+             AS number capability.";
+          reference
+            "RFC 6793: BGP Support for Four-Octet Autonomous System
+             (AS) Number Space, Section 3.";
+        }
+      }
+
+      container add-paths {
+        when "../../name = 'bt:add-paths'";
+        description
+          "BGP add-paths-specific values.";
+        reference
+          "RFC 7911: Advertisement of Multiple Paths in BGP.";
+
+        list afi-safis {
+          description
+            "List of AFI/SAFIs advertised by the BGP ADD-PATH
+             Capability and their AFI/SAFI-specific mode.";
+          leaf afi {
+            type iana-rt-types:address-family;
+            description
+              "Address Family Identifier for an instance of the BGP
+               ADD-PATH Capability.";
+            reference
+              "RFC 7911: Advertisement of Multiple Paths in BGP,
+               Section 4.";
+          }
+          leaf safi {
+            type iana-rt-types:bgp-safi;
+            description
+              "Subsequent Address Family Identifier for an instance
+               of the BGP ADD-PATH Capability.";
+            reference
+              "RFC 7911: Advertisement of Multiple Paths in BGP,
+               Section 4.";
+          }
+          leaf mode {
+            type enumeration {
+              enum receive {
+                value 1;
+                description "";
+              }
+              enum send {
+                value 2;
+                description "";
+              }
+              enum receive-send {
+                value 3;
+                description "";
+              }
+            }
+            description
+              "Send/Receive value for a per-AFI/SAFI instance of the
+               ADD-PATH Capability.";
+            reference
+              "RFC 7911: Advertisement of Multiple Paths in BGP,
+               Section 4.";
+          }
+        }
+      }
+    }
+  }
+
+  grouping bgp-capabilities {
+    description
+      "Structural grouping used to include BGP Capabiliites for BGP
+       neghbors.";
+
+    container capabilities {
+      config false;
+      description
+        "BGP Capabilities per-neighbor.";
+      reference
+        "RFC 5492: Capabilities Advertisement with BGP-4.";
+      
+      list advertised-capabilities {
+        key "code index";
+        description
+          "List of advertised BGP capabilities, per-peer.
+           Identified by the Capability Code and an index.  The
+           index covers the case where the same BGP Capability
+           may be advertised more than once.";
+
+        uses bgp-capabilities-common;
+      }
+
+      list received-capabilities {
+        key "code index";
+        description
+          "List of received BGP capabilities, per-peer.
+           Identified by the Capability Code and an index.  The
+           index covers the case where the same BGP Capability
+           may be advertised more than once.";
+
+        uses bgp-capabilities-common;
+      }
+
+      leaf-list negotiated-capabilities {
+        type identityref {
+          base bt:bgp-capability;
+        }
+        description
+          "Negotiated BGP capabilities.";
+      }
+    }
+  }
+}

--- a/src/yang/ietf-bgp-capabilities.yang
+++ b/src/yang/ietf-bgp-capabilities.yang
@@ -7,10 +7,13 @@ submodule ietf-bgp-capabilities {
   import iana-bgp-types {
     prefix bt;
     reference
-      "RFC XXXX: BGP Model for Service Provider Network.";
+      "RFC XXXX: YANG Model for Border Gateway Protocol (BGP-4).";
+
   }
   import iana-routing-types {
     prefix iana-rt-types;
+    reference
+      "RFC 8294: Common YANG Data Types for the Routing Area.";
   }
   import ietf-inet-types {
     prefix inet;
@@ -30,7 +33,7 @@ submodule ietf-bgp-capabilities {
               Jeffrey Haas (jhaas at juniper.net).";
 
   description
-    "This sub-module contains groupings that used for BGP 
+    "This sub-module contains groupings that used for BGP
      Capabilities within the BGP module.
 
      Copyright (c) 2023 IETF Trust and the persons identified as
@@ -57,22 +60,25 @@ submodule ietf-bgp-capabilities {
     description
       "Initial Version";
     reference
-      "RFC XXXX, BGP Model for Service Provider Network.";
+      "RFC XXXX: YANG Model for Border Gateway Protocol (BGP-4).";
   }
 
   grouping bgp-capabilities-common {
     description
-      "BGP Capabilities that are used commonly in by the
+      "BGP Capabilities that are used commonly by the
        advertised-capabilities and received-capabilities lists in the
        bgp-capabilities grouping.";
 
     leaf code {
-      type uint8;
+      type uint8 {
+        range 1..255;
+      }
       description
         "BGP Capability Code";
       reference
         "RFC 5492: Capabilities Advertisement with BGP-4, Section
-         4."; }
+         4.";
+    }
     leaf index {
       type uint8;
       description
@@ -84,7 +90,8 @@ submodule ietf-bgp-capabilities {
          Capability.";
       reference
         "RFC 5492: Capabilities Advertisement with BGP-4, Section
-         4."; }
+         4.";
+    }
     leaf name {
       type identityref {
         base bt:bgp-capability;
@@ -147,11 +154,21 @@ submodule ietf-bgp-capabilities {
 
         leaf flags {
           type bits {
-            /* XXX JMH - how do we show unknown bits? */
             bit restart {
               position 0;
               description
-                "";
+                "The most significant bit is defined as the Restart
+                 State (R) bit, which can be used to avoid possible
+                 deadlock caused by waiting for the End-of-RIB marker
+                 when multiple BGP speakers peering with each other
+                 restart.  When set (value 1), this bit indicates
+                 that the BGP speaker has restarted, and its peer
+                 MUST NOT wait for the End-of-RIB marker from the
+                 speaker before advertising routing information to
+                 the speaker.";
+              reference
+                "RFC 4724: Graceful Restart Mechanism for BGP,
+                 Section 3.";
             }
           }
           description
@@ -199,13 +216,20 @@ submodule ietf-bgp-capabilities {
                3.";
           }
           leaf afi-safi-flags {
-            /* XXX JMH - refactor */
             type bits {
-              /* XXX JMH - how do we show unknown bits? */
               bit forwarding-preserved {
                 position 0;
                 description
-                  "";
+                  "The most significant bit is defined as the
+                   Forwarding State (F) bit, which can be used to
+                   indicate whether the forwarding state for routes
+                   that were advertised with the given AFI and SAFI
+                   has indeed been preserved during the previous BGP
+                   restart.  When set (value 1), the bit indicates
+                   that the forwarding state has been preserved.";
+                 reference
+                   "RFC 4724: Graceful Restart Mechanism for BGP,
+                    Section 3.";
               }
             }
             description
@@ -270,15 +294,30 @@ submodule ietf-bgp-capabilities {
             type enumeration {
               enum receive {
                 value 1;
-                description "";
+                description
+                  "The sender of the capability is able to receive
+                   multiple paths from its peer.";
+                reference
+                  "RFC 7911: Advertisement of Multiple Paths in BGP,
+                   Section 4.";
               }
               enum send {
                 value 2;
-                description "";
+                description
+                  "The sender of the capability is able to send
+                   multiple paths to its peer.";
+                reference
+                  "RFC 7911: Advertisement of Multiple Paths in BGP,
+                   Section 4.";
               }
               enum receive-send {
                 value 3;
-                description "";
+                description
+                  "The sender of the capability is able both receive
+                   and send multiple paths for its peer.";
+                reference
+                  "RFC 7911: Advertisement of Multiple Paths in BGP,
+                   Section 4.";
               }
             }
             description
@@ -304,7 +343,7 @@ submodule ietf-bgp-capabilities {
         "BGP Capabilities per-neighbor.";
       reference
         "RFC 5492: Capabilities Advertisement with BGP-4.";
-      
+
       list advertised-capabilities {
         key "code index";
         description

--- a/src/yang/ietf-bgp-capabilities.yang
+++ b/src/yang/ietf-bgp-capabilities.yang
@@ -180,11 +180,7 @@ submodule ietf-bgp-capabilities {
         }
 
         leaf restart-time {
-          /* XXX JMH - create new ranged type. */
-          type uint16 {
-            range "0..4096";
-          }
-          units "seconds";
+          type bt:graceful-restart-time-type;
           description
             "The period of time (advertised by the peer) that the
              peer expects a restart of a BGP session to take.";

--- a/src/yang/ietf-bgp-common.yang
+++ b/src/yang/ietf-bgp-common.yang
@@ -392,9 +392,7 @@ submodule ietf-bgp-common {
         "Enable or disable the graceful-restart capability.";
     }
     leaf restart-time {
-      type uint16 {
-        range "0..4096";
-      }
+      type bt:graceful-restart-time-type;
       description
         "Estimated time (in seconds) for the local BGP speaker to
          restart a session. This value is advertise in the graceful

--- a/src/yang/ietf-bgp-policy.yang
+++ b/src/yang/ietf-bgp-policy.yang
@@ -200,7 +200,7 @@ module ietf-bgp-policy {
           }
           leaf-list member {
             type union {
-	      type bt:bgp-ext-community-type;
+              type bt:bgp-ext-community-type;
               type bt:bgp-community-regexp-type;
             }
             description

--- a/src/yang/ietf-bgp.yang
+++ b/src/yang/ietf-bgp.yang
@@ -49,6 +49,9 @@ module ietf-bgp {
     reference
       "RFC 8177: YANG Data Model for Key Chains";
   }
+  include ietf-bgp-capabilities {
+    revision-date YYYY-MM-DD;
+  }
   include ietf-bgp-common {
     revision-date YYYY-MM-DD;
   }
@@ -176,6 +179,7 @@ module ietf-bgp {
         type uint16 {
           range "0..4096";
         }
+        units "seconds";
         config false;
         description
           "The period of time (advertised by the peer) that the
@@ -591,14 +595,9 @@ module ietf-bgp {
                in UTC (assuming the session is in the Established
                state, per the session-state leaf).";
           }
-          leaf-list negotiated-capabilities {
-            type identityref {
-              base bt:bgp-capability;
-            }
-            config false;
-            description
-              "Negotiated BGP capabilities.";
-          }
+
+          uses bgp-capabilities;
+
           leaf negotiated-hold-time {
             type uint16;
             config false;

--- a/src/yang/ietf-bgp.yang
+++ b/src/yang/ietf-bgp.yang
@@ -176,10 +176,7 @@ module ietf-bgp {
          BGP";
       uses graceful-restart-config;
       leaf peer-restart-time {
-        type uint16 {
-          range "0..4096";
-        }
-        units "seconds";
+        type bt:graceful-restart-time-type;
         config false;
         description
           "The period of time (advertised by the peer) that the


### PR DESCRIPTION
The OC-inherited model only showed "negotiated capabilities".  There's an operational need to be able to show the sent/received capabilities and their capability-specific data.

Closes #248 