### PR TITLE
Issue #254 Remove extended bit from path unknown path attribute

### DIFF
--- a/src/yang/ietf-bgp-rib-attributes.yang
+++ b/src/yang/ietf-bgp-rib-attributes.yang
@@ -128,17 +128,6 @@ submodule ietf-bgp-rib-attributes {
             "RFC 4271 - A Border Gateway Protocol 4 (BGP-4)";
         }
 
-        leaf extended {
-          type boolean;
-          description
-            "Defines whether the attribute length is one octet
-             (if set to false) or two octets (if set to true). Set in
-             the fourth high-order bit of the BGP attribute flags
-             octet.";
-          reference
-            "RFC 4271 - A Border Gateway Protocol 4 (BGP-4)";
-        }
-
         leaf attr-type {
           type uint8;
           description
@@ -153,7 +142,11 @@ submodule ietf-bgp-rib-attributes {
             "One or two octet attribute length field indicating the
              length of the attribute data in octets.  If the Extended
              Length attribute flag is set, the length field is 2
-             octets, otherwise it is 1 octet";
+             octets, otherwise it is 1 octet
+
+             Note that the Extended Length bit is not present in this
+             model since implementations are not required to preserve
+             it.";
           reference
             "RFC 4271 - A Border Gateway Protocol 4 (BGP-4)";
         }


### PR DESCRIPTION
The unknown-attr model IETF inherited from the OpenConfig model included a boolean flag for the "extended" bit in the Path Attribute flags.  This flag is used to indicate that the length field after the Path Code is either one or two octets in length.

This flag is not required to be preserved by the protocol since the length itself is normally enough to indicate whether two-octet encoding is required.

There is an edge case that length < 256 octets for a path attribute may be encoded as a two-octet field.  While this isn't the usual desired encoding, it's still valid and introduces no headaches.  RFC 4271 and RFC 7606 are silent about such a case.

Since implementations aren't required to preserve the received Extended flag, remove it from this model and document the reason in the length field.

Closes #254 