### PR TITLE
Issue #255 Address structure of secure-session

### DIFF
--- a/src/yang/example-bgp-configuration-a.1.2.xml
+++ b/src/yang/example-bgp-configuration-a.1.2.xml
@@ -86,10 +86,14 @@
           <neighbor>
             <remote-address>2001:db8::</remote-address>
             <enabled>true</enabled>
-            <secure-session-enable>true</secure-session-enable>
-            <secure-session>
-              <ao-keychain>bgp-key-chain</ao-keychain>
-            </secure-session>
+            <transport>
+              <secure-session>
+                <enabled>true</enabled>
+                <options>
+                  <ao-keychain>bgp-key-chain</ao-keychain>
+                </options>
+              </secure-session>
+            </transport>
             <peer-as>64497</peer-as>
             <description>"Peer Router B"</description>
             <timers>

--- a/src/yang/ietf-bgp-common.yang
+++ b/src/yang/ietf-bgp-common.yang
@@ -401,6 +401,20 @@ submodule ietf-bgp-common {
               "RFC 5925: The TCP Authentication Option.";
           }
 
+          case ipsec {
+            leaf sa {
+              type string;
+              description
+                "Security Association (SA) name.";
+            }
+            description
+              "Currently, the IPsec/IKE YANG model has no
+               grouping defined that this model can use. When
+               such a grouping is defined, this model can import
+               the grouping to add the key parameters
+               needed to kick of IKE.";
+          }
+
           description
             "Choice of authentication options.";
         }

--- a/src/yang/ietf-bgp-common.yang
+++ b/src/yang/ietf-bgp-common.yang
@@ -9,6 +9,11 @@ submodule ietf-bgp-common {
     reference
       "RFC XXXX: BGP Model for Service Provider Network.";
   }
+  import ietf-key-chain {
+    prefix key-chain;
+    reference
+      "RFC 8177: YANG Data Model for Key Chains";
+  }
   import ietf-inet-types {
     prefix inet;
     reference
@@ -338,6 +343,68 @@ submodule ietf-bgp-common {
          the session when sending BGP update messages. This may be
          expressed as either an IP address or reference to the name
          of an interface.";
+    }
+
+    container secure-session {
+      must "enabled = 'false' or " +
+           "(enabled = 'true' and options)" {
+        error-message "When secure-session is enabled " +
+          "secure-session options MUST be set";
+      }
+      description
+        "Container for describing how a particular BGP session
+         is to be secured.";
+
+      leaf enabled {
+        type boolean;
+        default "false";
+        description
+          "When set to true, session is secured with the
+           configured options.";
+      }
+
+      container options {
+        description
+          "Options for securing the BGP session.";
+        choice option {
+          case ao {
+            leaf ao-keychain {
+              type key-chain:key-chain-ref;
+              description
+                "Reference to the key chain that will be used by this
+                 model. Applicable for TCP-AO and TCP-MD5 only";
+              reference
+                "RFC 8177: YANG Key Chain.";
+            }
+            description
+              "Uses TCP-AO to secure the session. Parameters for
+               those are defined as a grouping in the TCP YANG
+               model.";
+            reference
+              "RFC 5925 - The TCP Authentication Option.";
+          }
+
+          case md5 {
+            leaf md5-keychain {
+              type key-chain:key-chain-ref;
+              description
+                "Reference to the key chain that will be used by this
+                 model. Applicable for TCP-AO and TCP-MD5 only";
+              reference
+                "RFC 8177: YANG Key Chain.";
+            }
+            description
+              "Uses TCP-MD5 to secure the session. Parameters for
+               those are defined as a grouping in the TCP YANG
+               model.";
+            reference
+              "RFC 5925: The TCP Authentication Option.";
+          }
+
+          description
+            "Choice of authentication options.";
+        }
+      }
     }
 
     container bfd {

--- a/src/yang/ietf-bgp-common.yang
+++ b/src/yang/ietf-bgp-common.yang
@@ -12,7 +12,7 @@ submodule ietf-bgp-common {
   import ietf-key-chain {
     prefix key-chain;
     reference
-      "RFC 8177: YANG Data Model for Key Chains";
+      "RFC 8177: YANG Data Model for Key Chains.";
   }
   import ietf-inet-types {
     prefix inet;
@@ -374,14 +374,14 @@ submodule ietf-bgp-common {
                 "Reference to the key chain that will be used by this
                  model. Applicable for TCP-AO and TCP-MD5 only";
               reference
-                "RFC 8177: YANG Key Chain.";
+                "RFC 8177: YANG Data Model for Key Chains.";
             }
             description
               "Uses TCP-AO to secure the session. Parameters for
                those are defined as a grouping in the TCP YANG
                model.";
             reference
-              "RFC 5925 - The TCP Authentication Option.";
+              "RFC 5925:he TCP Authentication Option.";
           }
 
           case md5 {
@@ -391,7 +391,7 @@ submodule ietf-bgp-common {
                 "Reference to the key chain that will be used by this
                  model. Applicable for TCP-AO and TCP-MD5 only";
               reference
-                "RFC 8177: YANG Key Chain.";
+                "RFC 8177: YANG Data Model for Key Chains.";
             }
             description
               "Uses TCP-MD5 to secure the session. Parameters for

--- a/src/yang/ietf-bgp-common.yang
+++ b/src/yang/ietf-bgp-common.yang
@@ -381,7 +381,7 @@ submodule ietf-bgp-common {
                those are defined as a grouping in the TCP YANG
                model.";
             reference
-              "RFC 5925:he TCP Authentication Option.";
+              "RFC 5925: The TCP Authentication Option.";
           }
 
           case md5 {

--- a/src/yang/ietf-bgp.yang
+++ b/src/yang/ietf-bgp.yang
@@ -44,11 +44,6 @@ module ietf-bgp {
     reference
       "RFC 6991: Common YANG Data Types.";
   }
-  import ietf-key-chain {
-    prefix key-chain;
-    reference
-      "RFC 8177: YANG Data Model for Key Chains";
-  }
   include ietf-bgp-common {
     revision-date YYYY-MM-DD;
   }
@@ -459,69 +454,6 @@ module ietf-bgp {
               "RFC 4271, Section 8.1.2.";
           }
 
-          container secure-session {
-            must "enabled = 'false' or " +
-                 "(enabled = 'true' and options)" {
-              error-message "When secure-session is enabled " +
-                "secure-session options MUST be set";
-            }
-            description
-              "Container for describing how a particular BGP session
-               is to be secured.";
-
-            leaf enabled {
-              type boolean;
-              default "false";
-              description
-                "When set to true, session is secured with the
-                 configured options.";
-            }
-
-            container options {
-              description
-                "Options for securing the BGP session.";
-              choice option {
-                case ao {
-                  leaf ao-keychain {
-                    type key-chain:key-chain-ref;
-                    description
-                      "Reference to the key chain that will be used
-                       by this model. Applicable for TCP-AO and
-                       TCP-MD5 only";
-                    reference
-                      "RFC 8177: YANG Key Chain.";
-                  }
-                  description
-                    "Uses TCP-AO to secure the session. Parameters
-                     for those are defined as a grouping in the TCP
-                     YANG model.";
-                  reference
-                    "RFC 5925 - The TCP Authentication Option.";
-                }
-
-                case md5 {
-                  leaf md5-keychain {
-                    type key-chain:key-chain-ref;
-                    description
-                      "Reference to the key chain that will be used
-                       by this model. Applicable for TCP-AO and
-                       TCP-MD5 only";
-                    reference
-                      "RFC 8177: YANG Key Chain.";
-                  }
-                  description
-                    "Uses TCP-MD5 to secure the session. Parameters
-                     for those are defined as a grouping in the TCP
-                     YANG model.";
-                  reference
-                    "RFC 5925: The TCP Authentication Option.";
-                }
-
-                description
-                  "Choice of authentication options.";
-              }
-            }
-          }
           leaf ttl-security {
             if-feature "bt:ttl-security";
             type uint8;
@@ -991,72 +923,6 @@ module ietf-bgp {
             type string;
             description
               "Name of the BGP peer-group";
-          }
-
-          leaf secure-session-enable {
-            type boolean;
-            default "false";
-            description
-              "Does this session need to be secured?";
-          }
-
-          container secure-session {
-            when "../secure-session-enable = 'true'";
-            description
-              "Container for describing how a particular BGP session
-               is to be secured.";
-
-            choice option {
-              case ao {
-                leaf ao-keychain {
-                  type key-chain:key-chain-ref;
-                  description
-                    "Reference to the key chain that will be used by
-                     this model. Applicable for TCP-AO and TCP-MD5
-                     only";
-                  reference
-                    "RFC 8177: YANG Key Chain.";
-                }
-                description
-                  "Uses TCP-AO to secure the session. Parameters for
-                   those are defined as a grouping in the TCP YANG
-                   model.";
-                reference
-                  "RFC 5925 - The TCP Authentication Option.";
-              }
-              case md5 {
-                leaf md5-keychain {
-                  type key-chain:key-chain-ref;
-                  description
-                    "Reference to the key chain that will be used by
-                     this model. Applicable for TCP-AO and TCP-MD5
-                     only";
-                  reference
-                    "RFC 8177: YANG Key Chain.";
-                }
-                description
-                  "Uses TCP-MD5 to secure the session. Parameters for
-                   those are defined as a grouping in the TCP YANG
-                   model.";
-                reference
-                  "RFC 5925: The TCP Authentication Option.";
-              }
-              case ipsec {
-                leaf sa {
-                  type string;
-                  description
-                    "Security Association (SA) name.";
-                }
-                description
-                  "Currently, the IPsec/IKE YANG model has no
-                   grouping defined that this model can use. When
-                   such a grouping is defined, this model can import
-                   the grouping to add the key parameters
-                   needed to kick of IKE.";
-              }
-              description
-                "Choice of authentication options.";
-            }
           }
 
           leaf ttl-security {

--- a/src/yang/ietf-bgp.yang
+++ b/src/yang/ietf-bgp.yang
@@ -459,18 +459,18 @@ module ietf-bgp {
               "RFC 4271, Section 8.1.2.";
           }
 
-          leaf secure-session-enable {
-            type boolean;
-            default "false";
-            description
-              "Does this session need to be secured?";
-          }
-
           container secure-session {
-            when "../secure-session-enable = 'true'";
             description
               "Container for describing how a particular BGP session
                is to be secured.";
+
+            leaf enabled {
+              type boolean;
+              default "false";
+              description
+                "When set to true, session is secured with the
+                 configured options.";
+            }
 
             choice option {
               case ao {
@@ -511,6 +511,11 @@ module ietf-bgp {
 
               description
                 "Choice of authentication options.";
+            }
+            must "enabled = 'false' or " +
+                 "(enabled = 'true' and option != ''" {
+              error-message "When secure-session is enabled " +
+                "secure-session options MUST be set";
             }
           }
           leaf ttl-security {

--- a/src/yang/ietf-bgp.yang
+++ b/src/yang/ietf-bgp.yang
@@ -460,6 +460,11 @@ module ietf-bgp {
           }
 
           container secure-session {
+            must "enabled = 'false' or " +
+                 "(enabled = 'true' and options)" {
+              error-message "When secure-session is enabled " +
+                "secure-session options MUST be set";
+            }
             description
               "Container for describing how a particular BGP session
                is to be secured.";
@@ -472,50 +477,49 @@ module ietf-bgp {
                  configured options.";
             }
 
-            choice option {
-              case ao {
-                leaf ao-keychain {
-                  type key-chain:key-chain-ref;
-                  description
-                    "Reference to the key chain that will be used by
-                     this model. Applicable for TCP-AO and TCP-MD5
-                     only";
-                  reference
-                    "RFC 8177: YANG Key Chain.";
-                }
-                description
-                  "Uses TCP-AO to secure the session. Parameters for
-                   those are defined as a grouping in the TCP YANG
-                   model.";
-                reference
-                  "RFC 5925 - The TCP Authentication Option.";
-              }
-
-              case md5 {
-                leaf md5-keychain {
-                  type key-chain:key-chain-ref;
-                  description
-                    "Reference to the key chain that will be used by
-                     this model. Applicable for TCP-AO and TCP-MD5
-                     only";
-                  reference
-                    "RFC 8177: YANG Key Chain.";
-                }
-                description
-                  "Uses TCP-MD5 to secure the session. Parameters for
-                   those are defined as a grouping in the TCP YANG
-                   model.";
-                reference
-                  "RFC 5925: The TCP Authentication Option.";
-              }
-
+            container options {
               description
-                "Choice of authentication options.";
-            }
-            must "enabled = 'false' or " +
-                 "(enabled = 'true' and option != ''" {
-              error-message "When secure-session is enabled " +
-                "secure-session options MUST be set";
+                "Options for securing the BGP session.";
+              choice option {
+                case ao {
+                  leaf ao-keychain {
+                    type key-chain:key-chain-ref;
+                    description
+                      "Reference to the key chain that will be used
+                       by this model. Applicable for TCP-AO and
+                       TCP-MD5 only";
+                    reference
+                      "RFC 8177: YANG Key Chain.";
+                  }
+                  description
+                    "Uses TCP-AO to secure the session. Parameters
+                     for those are defined as a grouping in the TCP
+                     YANG model.";
+                  reference
+                    "RFC 5925 - The TCP Authentication Option.";
+                }
+
+                case md5 {
+                  leaf md5-keychain {
+                    type key-chain:key-chain-ref;
+                    description
+                      "Reference to the key chain that will be used
+                       by this model. Applicable for TCP-AO and
+                       TCP-MD5 only";
+                    reference
+                      "RFC 8177: YANG Key Chain.";
+                  }
+                  description
+                    "Uses TCP-MD5 to secure the session. Parameters
+                     for those are defined as a grouping in the TCP
+                     YANG model.";
+                  reference
+                    "RFC 5925: The TCP Authentication Option.";
+                }
+
+                description
+                  "Choice of authentication options.";
+              }
             }
           }
           leaf ttl-security {


### PR DESCRIPTION
Issue #255 Address structure of secure-session
    
The enabled boolean didn't reside in the container with the secure-session
parameters themselves.  The constraint on the existing options had a constraint
that you couldn't configure options without setting the enabled status to true.
This is the opposite of how you'd normally want this to operate.
    
Move the enabled into the secure-session container.
Create a must constraint that when enabled, options MUST be configured.
To support the must constraint, put the current choice option into new container "options" to provide a XPath testable element.
Move secure-session into the transport container and remove redundant copy under peer-groups.
Fix the examples using secure-session.

Closes #255 