### PR TITLE
Issue #243 - Don't use ipv4-address type for things that want dotted-quad

### DIFF
--- a/src/yang/iana-bgp-types.yang
+++ b/src/yang/iana-bgp-types.yang
@@ -6,6 +6,11 @@ module iana-bgp-types {
   import ietf-inet-types {
     prefix inet;
   }
+  import ietf-yang-types {
+    prefix yang;
+    reference
+      "RFC 6991: Common YANG Types.";
+  }
 
   // meta
 
@@ -611,7 +616,7 @@ module iana-bgp-types {
   typedef rr-cluster-id-type {
     type union {
       type uint32;
-      type inet:ipv4-address;
+      type yang:dotted-quad;
     }
     description
       "Union type for route reflector cluster ids:

--- a/src/yang/ietf-bgp-rib.yang
+++ b/src/yang/ietf-bgp-rib.yang
@@ -213,12 +213,18 @@ submodule ietf-bgp-rib {
           description
             "AS number of the autonomous system that performed the
              aggregation.";
+          reference
+            "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section
+             4.3, Path Attributes (g).";
         }
-        leaf address {
-          type inet:ipv4-address;
+        leaf identifier {
+          type yang:dotted-quad;
           description
-            "IP address of the router that performed the
+            "BGP Identifier of the router that performed the
              aggregation.";
+          reference
+            "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section
+             4.3, Path Attributes (g).";
         }
       }
       container aggregator4 {
@@ -233,7 +239,7 @@ submodule ietf-bgp-rib {
            aggregator/as leaf regardless of being 4-octet or
            2-octet.";
         reference
-          "RFC 4271: Section 5.1.7.";
+          "RFC 6793: BGP Support for Four-octet AS Number Space.";
         leaf as4 {
           type inet:as-number;
           description
@@ -243,13 +249,21 @@ submodule ietf-bgp-rib {
              Its semantics are similar to the AS4_PATH optional
              transitive attribute";
           reference
-            "RFC 6793 - BGP Support for Four-octet AS Number Space";
+            "RFC 6793: BGP Support for Four-octet AS Number Space,
+             Section 3,
+             RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section
+             4.3, Path Attributes (g).";
         }
-        leaf address {
-          type inet:ipv4-address;
+        leaf identifier {
+          type yang:dotted-quad;
           description
-            "IP address of the router that performed the
+            "BGP Identifier of the router that performed the
              aggregation.";
+          reference
+            "RFC 6793: BGP Support for Four-octet AS Number Space,
+             Section 3,
+             RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section
+             4.3, Path Attributes (g).";
         }
       }
       leaf atomic-aggregate {


### PR DESCRIPTION
Change the aggregator "address" and cluster-list entries to use type dotted-quad.  These elements want to use a BGP Identifier for their contents. The ipv4-address type includes the scoped address case, which is inappropriate for those leaves.

Secondarily, change aggregate leaf "address" to "identifier" to more correctly reflect that this isn't an IP address.

Closes #243 