### PR TITLE
Issue #277 - Hold and established time changes

### DIFF
--- a/src/yang/ietf-bgp-common.yang
+++ b/src/yang/ietf-bgp-common.yang
@@ -121,6 +121,15 @@ submodule ietf-bgp-common {
         "RFC 4271, Section 4.2.
          RFC 4271, Section 10.";
     }
+    leaf negotiated-hold-time {
+      type uint16;
+      config false;
+      description
+        "The negotiated hold-time for the BGP session";
+      reference
+        "RFC 4271, Section 4.2.
+         RFC 4271, Section 10.";
+    }
     leaf keepalive {
       type uint16 {
         range "0..21845";

--- a/src/yang/ietf-bgp.yang
+++ b/src/yang/ietf-bgp.yang
@@ -590,6 +590,8 @@ module ietf-bgp {
                the difference between this value and the current time
                in UTC (assuming the session is in the Established
                state, per the session-state leaf).";
+            reference
+              "RFC 4271, Section 8.";
           }
           leaf-list negotiated-capabilities {
             type identityref {
@@ -598,12 +600,6 @@ module ietf-bgp {
             config false;
             description
               "Negotiated BGP capabilities.";
-          }
-          leaf negotiated-hold-time {
-            type uint16;
-            config false;
-            description
-              "The negotiated hold-time for the BGP session";
           }
           leaf last-error {
             type binary {
@@ -619,21 +615,6 @@ module ietf-bgp {
                contains the subcode.";
             reference
               "RFC 4271, Section 4.5.";
-          }
-          leaf fsm-established-time {
-            type yang:gauge32;
-            units "seconds";
-            config false;
-            description
-              "This timer indicates how long (in
-               seconds) this peer has been in the
-               established state or how long
-               since this peer was last in the
-               established state.  It is set to zero when
-               a new peer is configured or when the router is
-               booted.";
-            reference
-              "RFC 4271, Section 8.";
           }
           leaf treat-as-withdraw {
             type boolean;


### PR DESCRIPTION
Move the negotiated-hold-time leaf to the timers container.

Remove the fsm-established-time leaf.  The leaf, last-established, covers the event when we transition in and out of Established.  The timer that's being deleted can be derived from the last-established timestamp and the current session-state.  This is also more consistent with the OpenConfig model.

Closes #277