### PR TITLE
Issue #253 - Remove redundant bfd container, change local-address

### DIFF
--- a/src/yang/example-bgp-configuration-a.1.1.xml
+++ b/src/yang/example-bgp-configuration-a.1.1.xml
@@ -42,15 +42,15 @@
                 <name>bt:ipv4-unicast</name>
               </afi-safi>
             </afi-safis>
-            <bfd>
-              <enabled>true</enabled>
-              <local-multiplier>2</local-multiplier>
-              <desired-min-tx-interval>3300</desired-min-tx-interval>
-              <required-min-rx-interval>3300</required-min-rx-interval>
-            </bfd>
 	    <transport>
 	      <tcp-mss>1400</tcp-mss>
 	      <mtu-discovery>true</mtu-discovery>
+              <bfd>
+                <enabled>true</enabled>
+                <local-multiplier>2</local-multiplier>
+                <desired-min-tx-interval>3300</desired-min-tx-interval>
+                <required-min-rx-interval>3300</required-min-rx-interval>
+              </bfd>
 	    </transport>
           </neighbor>
         </neighbors>

--- a/src/yang/ietf-bgp-common.yang
+++ b/src/yang/ietf-bgp-common.yang
@@ -202,7 +202,6 @@ submodule ietf-bgp-common {
          this differs from the global BGP router autonomous system
          number.";
     }
-
     leaf remove-private-as {
       type bt:remove-private-as-option;
       description
@@ -308,6 +307,20 @@ submodule ietf-bgp-common {
       "Configuration parameters relating to the transport protocol
        used by the BGP session to the peer.";
 
+    leaf local-address {
+      type union {
+        type inet:ip-address;
+        type leafref {
+          path "../../../../interfaces/interface/name";
+        }
+      }
+      description
+        "Set the local IP (either IPv4 or IPv6) address to use for
+         the session when sending BGP update messages. This may be
+         expressed as either an IP address or reference to the name
+         of an interface.";
+    }
+
     leaf tcp-mss {
       type tcp:mss;
       description
@@ -355,20 +368,6 @@ submodule ietf-bgp-common {
       description
         "Wait for peers to issue requests to open a BGP session,
          rather than initiating sessions from the local router.";
-    }
-
-    leaf local-address {
-      type union {
-        type inet:ip-address;
-        type leafref {
-          path "../../../../interfaces/interface/name";
-        }
-      }
-      description
-        "Set the local IP (either IPv4 or IPv6) address to use for
-         the session when sending BGP update messages. This may be
-         expressed as either an IP address or reference to the name
-         of an interface.";
     }
 
     container bfd {

--- a/src/yang/ietf-bgp-common.yang
+++ b/src/yang/ietf-bgp-common.yang
@@ -11,6 +11,8 @@ submodule ietf-bgp-common {
   }
   import ietf-interfaces {
     prefix if;
+    reference
+      "RFC 7223: A YANG Data Model for Interface Management.";
   }
   import ietf-inet-types {
     prefix inet;

--- a/src/yang/ietf-bgp-common.yang
+++ b/src/yang/ietf-bgp-common.yang
@@ -9,6 +9,9 @@ submodule ietf-bgp-common {
     reference
       "RFC XXXX: BGP Model for Service Provider Network.";
   }
+  import ietf-interfaces {
+    prefix if;
+  }
   import ietf-inet-types {
     prefix inet;
     reference
@@ -310,9 +313,7 @@ submodule ietf-bgp-common {
     leaf local-address {
       type union {
         type inet:ip-address;
-        type leafref {
-          path "../../../../interfaces/interface/name";
-        }
+        type if:interface-ref;
       }
       description
         "Set the local IP (either IPv4 or IPv6) address to use for

--- a/src/yang/ietf-bgp.yang
+++ b/src/yang/ietf-bgp.yang
@@ -1070,37 +1070,6 @@ module ietf-bgp {
         }
       }
 
-      container interfaces {
-        list interface {
-          key "name";
-          leaf name {
-            type if:interface-ref;
-            description
-              "Reference to the interface within the routing
-               instance.";
-          }
-
-          container bfd {
-            if-feature "bt:bfd";
-            leaf enabled {
-              type boolean;
-              default "false";
-              description
-                "Indicates whether BFD is enabled on this
-                 interface.";
-            }
-            description
-              "BFD client configuration.";
-            reference
-              "RFC 9314: YANG Data Model for Bidirectional Forward
-               Detection (BFD).";
-          }
-          description
-            "List of interfaces within the routing instance.";
-        }
-        description
-          "Interface specific parameters.";
-      }
       uses rib;
     }
   }

--- a/src/yang/ietf-bgp.yang
+++ b/src/yang/ietf-bgp.yang
@@ -28,12 +28,6 @@ module ietf-bgp {
     reference
       "RFC XXXX, BGP YANG Model for Service Provider Network.";
   }
-  import ietf-bfd-types {
-    prefix bfd-types;
-    reference
-      "RFC 9314: YANG Data Model for Bidirectional Forwarding
-       Detection (BFD).";
-  }
   import ietf-inet-types {
     prefix inet;
     reference

--- a/src/yang/ietf-bgp.yang
+++ b/src/yang/ietf-bgp.yang
@@ -628,13 +628,6 @@ module ietf-bgp {
                Messages.";
           }
 
-          container bfd {
-            if-feature "bt:bfd";
-            uses bfd-types:client-cfg-parms;
-            description
-              "BFD configuration per-neighbor.";
-          }
-
           container statistics {
             config false;
             description


### PR DESCRIPTION
There was a redundant bfd container left after cleanup. It has been removed. 

bgp/[...]/transport/local-address appears redundant, but in the current model it is used to configure the local-address.  The
bgp/neighbors/transport/local-address is currently operational-only state.

Removed the bgp/interfaces container.

Moved the local-address node up to the top of transport.

Closes #253
Closes #251 