### PR TITLE
Fix example a.1.2

### DIFF
--- a/src/yang/example-bgp-configuration-a.1.2.xml
+++ b/src/yang/example-bgp-configuration-a.1.2.xml
@@ -16,10 +16,7 @@
           <end-date-time>2017-02-01T00:00:05Z</end-date-time>
         </accept-lifetime>
       </lifetime>
-      <crypto-algorithm
-        xmlns:tcp=
-	"urn:ietf:params:xml:ns:yang:ietf-tcp">tcp:aes-128
-      </crypto-algorithm>
+      <crypto-algorithm>aes-cmac-prf-128</crypto-algorithm>
       <key-string>
         <keystring>testvector</keystring>
       </key-string>
@@ -44,10 +41,7 @@
           <end-date-time>2017-02-01T00:00:05Z</end-date-time>
         </accept-lifetime>
       </lifetime>
-      <crypto-algorithm
-        xmlns:tcp=
-	"urn:ietf:params:xml:ns:yang:ietf-tcp">tcp:aes-128
-      </crypto-algorithm>
+      <crypto-algorithm>aes-cmac-prf-128</crypto-algorithm>
       <key-string>
         <keystring>testvector</keystring>
       </key-string>


### PR DESCRIPTION
The example had a reference to a crypto algorithm that TCP-AO needs and was at a time defined in the TCP YANG module. Instead, it should be using the crypto algorithms already defined in ietf-key-chain model.

Address issue #267 