### PR TITLE
Issue #242 - Remove no-client reflect.

### DIFF
--- a/src/yang/ietf-bgp-common-structure.yang
+++ b/src/yang/ietf-bgp-common-structure.yang
@@ -105,15 +105,6 @@ submodule ietf-bgp-common-structure {
           "RFC 4456: BGP Route Reflection: An Alternative to
                      Full Mesh.";
       }
-      leaf no-client-reflect {
-        type boolean;
-        default "false";
-        description
-          "When set to 'true', this disables route redistribution
-           by the Route Reflector. It is set 'true' when the client
-           is fully meshed in its peer-group to prevent sending of
-           redundant route advertisements.";
-      }
       leaf client {
         type boolean;
         default "false";


### PR DESCRIPTION
Deployed implementations of BGP route-reflectors are highly inconsistent about their support for "no-client-reflect".  Since the set of if-features necessary to represent the whole set of deployed behaviors would unnecessarily complicate the model, remove the feature for the time being.

Closes #242