### PR TITLE
Issue #249 - Better operational state for errors

### DIFF
--- a/draft/Makefile
+++ b/draft/Makefile
@@ -50,13 +50,14 @@ endif
 	-rm -f ../bin/submodules/*\@$(shell date +%Y)*.yang
 	-rm -f ../bin/submodules/*\@$(shell date +%Y)*-*-*.yang
 
-$(next).xml: $(draft).xml ../src/yang/ietf-bgp-common-multiprotocol.yang ../src/yang/ietf-bgp-common-structure.yang ../src/yang/ietf-bgp-common.yang ../src/yang/ietf-bgp-neighbor.yang ../src/yang/ietf-bgp-policy.yang ../src/yang/iana-bgp-types.yang ../src/yang/ietf-bgp.yang rib
+$(next).xml: $(draft).xml ../src/yang/ietf-bgp-common-multiprotocol.yang ../src/yang/ietf-bgp-common-structure.yang ../src/yang/ietf-bgp-common.yang ../src/yang/ietf-bgp-neighbor.yang ../src/yang/ietf-bgp-policy.yang ../src/yang/iana-bgp-notification.yang ../src/yang/iana-bgp-types.yang ../src/yang/ietf-bgp.yang rib
 	sed -e"s/$(basename $<)-latest/$(basename $@)/" -e"s/YYYY-MM-DD/$(shell date +%Y-%m-%d)/" $< > $@
 	sed -e"s/YYYY-MM-DD/$(shell date +%Y-%m-%d)/" ../src/yang/ietf-bgp-common-multiprotocol.yang > ../bin/submodules/ietf-bgp-common-multiprotocol\@$(shell date +%Y-%m-%d).yang
 	sed -e"s/YYYY-MM-DD/$(shell date +%Y-%m-%d)/" ../src/yang/ietf-bgp-common-structure.yang > ../bin/submodules/ietf-bgp-common-structure\@$(shell date +%Y-%m-%d).yang
 	sed -e"s/YYYY-MM-DD/$(shell date +%Y-%m-%d)/" ../src/yang/ietf-bgp-common.yang > ../bin/submodules/ietf-bgp-common\@$(shell date +%Y-%m-%d).yang
 	sed -e"s/YYYY-MM-DD/$(shell date +%Y-%m-%d)/" ../src/yang/ietf-bgp-neighbor.yang > ../bin/submodules/ietf-bgp-neighbor\@$(shell date +%Y-%m-%d).yang
 	sed -e"s/YYYY-MM-DD/$(shell date +%Y-%m-%d)/" ../src/yang/ietf-bgp-policy.yang > ../bin/ietf-bgp-policy\@$(shell date +%Y-%m-%d).yang
+	sed -e"s/YYYY-MM-DD/$(shell date +%Y-%m-%d)/" ../src/yang/iana-bgp-notification.yang > ../bin/submodules/iana-bgp-notification\@$(shell date +%Y-%m-%d).yang
 	sed -e"s/YYYY-MM-DD/$(shell date +%Y-%m-%d)/" ../src/yang/iana-bgp-types.yang > ../bin/iana-bgp-types\@$(shell date +%Y-%m-%d).yang
 	sed -e"s/YYYY-MM-DD/$(shell date +%Y-%m-%d)/" ../src/yang/ietf-bgp.yang > ../bin/ietf-bgp\@$(shell date +%Y-%m-%d).yang
 	sed -e"s/YYYY-MM-DD/$(shell date +%Y-%m-%d)/" ../src/yang/example-newafi-bgp.yang > ../bin/example-newafi-bgp\@$(shell date +%Y-%m-%d).yang

--- a/draft/draft-ietf-idr-bgp-model.xml
+++ b/draft/draft-ietf-idr-bgp-model.xml
@@ -586,6 +586,7 @@ INSERT_TEXT_FROM_FILE(../bin/ietf-bgp@YYYY-MM-DD-rib-tree.txt)
         be made: <figure>
             <artwork><![CDATA[URI: urn:ietf:params:xml:ns:yang:ietf-bgp
 URI: urn:ietf:params:xml:ns:yang:ietf-bgp-policy
+URI: urn:ietf:params:xml:ns:yang:iana-bgp-notification
 URI: urn:ietf:params:xml:ns:yang:iana-bgp-types
 ]]></artwork>
           </figure></t>
@@ -607,6 +608,11 @@ reference: RFC XXXX
 name: ietf-bgp-policy
 namespace: urn:ietf:params:xml:ns:yang:ietf-bgp-policy
 prefix: bp
+reference: RFC XXXX
+
+name: iana-bgp-notification
+namespace: urn:ietf:params:xml:ns:yang:iana-bgp-notification
+prefix: bn
 reference: RFC XXXX
 
 name: iana-bgp-types
@@ -649,6 +655,9 @@ reference: RFC XXXX
 
       <t>Additionally, modules include:
       <ul>
+          <li>iana-bgp-notification - identity definitions for BGP NOTIFICATION
+          message Error Codes and Error subcodes.</li>
+
           <li>iana-bgp-types - common type and identity definitions for BGP,
           including BGP policy.</li>
 
@@ -751,6 +760,17 @@ INSERT_TEXT_FROM_FILE(../bin/submodules/ietf-bgp-neighbor@YYYY-MM-DD.yang)
             </figure>
 	  </t>
 	</section>
+      </section>
+
+      <section title="BGP notification module">
+        <t><figure>
+            <artwork><![CDATA[
+<CODE BEGINS> file "iana-bgp-notification@YYYY-MM-DD.yang"
+INSERT_TEXT_FROM_FILE(../bin/submodules/iana-bgp-notification@YYYY-MM-DD.yang)
+<CODE ENDS>
+
+        ]]></artwork>
+          </figure></t>
       </section>
 
       <section title="BGP types module">

--- a/src/yang/iana-bgp-notification.yang
+++ b/src/yang/iana-bgp-notification.yang
@@ -1,0 +1,802 @@
+module iana-bgp-notification {
+  yang-version 1.1;
+  namespace "urn:ietf:params:xml:ns:yang:iana-bgp-notification";
+  prefix bn;
+
+  // meta
+
+  organization
+    "IANA";
+  contact
+    "Internet Assigned Numbers Authority
+
+     Postal: ICANN
+             12025 Waterfront Drive, Suite 300
+             Los Angeles, CA 90094-2536
+             United States of America
+     Tel:    +1 310 301 5800
+     <mailto:iana@iana.org>
+
+     Authors: Mahesh Jethanandani (mjethanandani at gmail.com),
+              Keyur Patel (keyur at arrcus.com),
+              Susan Hares (shares at ndzh.com),
+              Jeffrey Haas (jhaas at juniper.net).";
+
+  description
+    "This YANG module is maintained by IANA and contains definitions
+     of identities used to represent BGP NOTIFICATION Error
+     code/Error Subcode tuples.  These values reflect the 
+     'BGP Error (Notification) Codes' and 'BGP Error Subcodes'
+     registry at IANA.
+
+     Copyright (c) 2023 IETF Trust and the persons identified as
+     authors of the code. All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject to
+     the license terms contained in, the Simplified BSD License set
+     forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (https://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC XXXX
+     (https://www.rfc-editor.org/info/rfcXXXX); see the RFC itself
+     for full legal notices.
+
+     The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL', 'SHALL
+     NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED', 'NOT RECOMMENDED',
+     'MAY', and 'OPTIONAL' in this document are to be interpreted as
+     described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
+     they appear in all capitals, as shown here.";
+
+  revision YYYY-MM-DD {
+    description
+      "Initial Version";
+    reference
+      "RFC XXX, BGP Model for Service Provider Network.";
+  }
+
+
+  identity bgp-notification {
+    description
+      "Base identity for BGP NOTIFICATION state.";
+  }
+
+  identity bgp-notification-message-header-error {
+    base bgp-notification;
+    description
+      "All errors detected while processing the Message Header MUST
+       be indicated by sending the NOTIFICATION message with the
+       Error Code Message Header Error.
+
+       The value of the 'Message Header Error' Error code is 1.";
+    reference
+      "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 6.1.";
+  }
+
+  identity bgp-message-header-unspecific {
+    base bgp-notification-message-header-error;
+    description
+      "If no appropriate Error Subcode is defined, then a zero
+       (Unspecific) value is used for the Error Subcode field.
+
+       The value of the 'Unspecific Error' subcode is 0.";
+    reference
+      "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 4.5.";
+  }
+
+  identity bgp-message-header-connection-not-synchronized {
+    base bgp-notification-message-header-error;
+    description
+      "If the Marker field of the message header is not as expected,
+       then a synchronization error has occurred and the Error
+       Subcode MUST be set to Connection Not Synchronized.
+
+       The value of the 'Conection Not Synchronized Error' subcode is
+       1.";
+    reference
+      "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 6.1.";
+  }
+
+  identity bgp-message-header-bad-message-length {
+    base bgp-notification-message-header-error;
+    description
+      "If at least one of the following is true:
+
+       - if the Length field of the message header is less than 19 or
+         greater than 4096, or
+
+       - if the Length field of an OPEN message is less than the
+         minimum length of the OPEN message, or
+
+       - if the Length field of an UPDATE message is less than the
+         minimum length of the UPDATE message, or
+
+       - if the Length field of a KEEPALIVE message is not equal to
+         19, or
+
+       - if the Length field of a NOTIFICATION message is less than
+         the minimum length of the NOTIFICATION message,
+
+       then the Error Subcode MUST be set to Bad Message Length.  The
+       Data field MUST contain the erroneous Length field.
+
+       The value of the 'Bad Message Length' Error subcode is 2.";
+    reference
+      "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 6.1.";
+  }
+
+  identity bgp-message-header-bad-message-type {
+    base bgp-notification-message-header-error;
+    description
+      "If the Type field of the message header is not recognized,
+       then the Error Subcode MUST be set to Bad Message Type.  The
+       Data field MUST contain the erroneous Type field.
+
+       The value of the 'Message Header Error' Error subcode is 3.";
+    reference
+      "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 6.1.";
+  }
+
+  identity bgp-notification-open-message-error {
+    base bgp-notification;
+    description
+      "All errors detected while processing the OPEN message MUST be
+       indicated by sending the NOTIFICATION message with the Error
+       Code 'OPEN Message Error'.
+
+       The value of the 'OPEN Message Error' Error code is 2.";
+    reference
+      "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 6.2.";
+  }
+
+  identity bgp-open-message-unspecific {
+    base bgp-notification-open-message-error;
+    description
+      "From Section 4.5:
+       If no appropriate Error Subcode is defined, then a zero
+       (Unspecific) value is used for the Error Subcode field.
+
+       The value of the 'Unspecific Error' subcode is 0.
+       
+       From Section 6.2:
+       If one of the Optional Parameters in the OPEN message is
+       recognized, but is malformed, then the Error Subcode MUST be
+       set to 0 (Unspecific).";
+    reference
+      "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 4.5.
+       RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 6.2.";
+  }
+
+  identity bgp-open-unsupported-version-number {
+    base bgp-notification-open-message-error;
+    description
+      "If the version number in the Version field of the received
+       OPEN message is not supported, then the Error Subcode MUST be
+       set to Unsupported Version Number.  The Data field is a
+       2-octet unsigned integer, which indicates the largest,
+       locally-supported version number less than the version the
+       remote BGP peer bid (as indicated in the received OPEN
+       message), or if the smallest, locally-supported version number
+       is greater than the version the remote BGP peer bid, then the
+       smallest, locally-supported version number.
+
+       The value of the 'Unsupported Version Number' Error subcode is
+       1.";
+    reference
+      "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 6.2.";
+  }
+
+  identity bgp-open-bad-peer-as {
+    base bgp-notification-open-message-error;
+    description
+      "If the Autonomous System field of the OPEN message is
+       unacceptable, then the Error Subcode MUST be set to Bad Peer
+       AS.  The determination of acceptable Autonomous System numbers
+       is outside the scope of this protocol.
+
+       The value of the 'Bad Peer AS' Error subcode is 2.";
+    reference
+      "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 6.2.";
+  }
+
+  identity bgp-open-bad-bgp-id {
+    base bgp-notification-open-message-error;
+    description
+      "From RFC 4271, Section 6.2:
+       If the BGP Identifier field of the OPEN message is
+       syntactically incorrect, then the Error Subcode MUST be set to
+       Bad BGP Identifier.  Syntactic correctness means that the BGP
+       Identifier field represents a valid unicast IP host address.
+
+       This was updated by RFC 6286:
+       For a BGP speaker that supports the AS-wide Unique BGP
+       Identifier, the OPEN message error handling related to the BGP
+       Identifier is modified as follows:
+
+       If the BGP Identifier field of the OPEN message is zero, or if
+       it is the same as the BGP Identifier of the local BGP speaker
+       and the message is from an internal peer, then the Error
+       Subcode is set to 'Bad BGP Identifier'.
+
+       The value of the 'Bad BGP Identifier' Error subcode is 3.";
+    reference
+      "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 6.2.
+       RFC 6286: Autonomous-System-Wide Unique BGP Identifier for
+       BGP-4., Section 2.2.";
+  }
+
+  identity bgp-open-unsupported-optional-parameter {
+    base bgp-notification-open-message-error;
+    description
+      "If one of the Optional Parameters in the OPEN message is not
+      recognized, then the Error Subcode MUST be set to Unsupported
+      Optional Parameters.
+
+      The value of the 'Unsupported Optional Parameter' Error subcode
+      is 4.";
+    reference
+      "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 6.2.";
+  }
+
+  identity bgp-open-unacceptable-hold-time {
+    base bgp-notification-open-message-error;
+    description
+      "If the Hold Time field of the OPEN message is unacceptable,
+       then the Error Subcode MUST be set to Unacceptable Hold Time.
+       An implementation MUST reject Hold Time values of one or two
+       seconds.  An implementation MAY reject any proposed Hold Time.
+       An implementation that accepts a Hold Time MUST use the
+       negotiated value for the Hold Time.
+
+       The value of the 'Unacceptable Hold Time' Error subcode is
+       6.";
+    reference
+      "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 6.2.";
+  }
+
+  identity bgp-open-unsupported-capability {
+    base bgp-notification-open-message-error;
+    description
+      "If a BGP speaker that supports a certain capability determines
+       that its peer doesn't support this capability, the speaker MAY
+       send a NOTIFICATION message to the peer and terminate peering
+       (see Section 'Extensions to Error Handling' for more details).
+       For example, a BGP speaker may need to terminate peering if it
+       established peering to exchange IPv6 routes and determines
+       that its peer does not support Multiprotocol Extensions for
+       BGP-4 [RFC4760].  The Error Subcode in the NOTIFICATION
+       message is then set to Unsupported Capability.  The message
+       MUST contain the capability or capabilities that cause the
+       speaker to send the message.
+
+       The value of the 'Unsupported Capability' Error subcode is
+       7.";
+    reference
+      "RFC 5492: Capabilities Advertisement with BGP-4, Section 3.";
+  }
+
+  identity bgp-open-role-mismatch {
+    base bgp-notification-open-message-error;
+    description
+      "If the BGP Role Capability is advertised, and one is also
+       received from the peer, the Roles MUST correspond to the
+       relationships in Table 2. If the Roles do not correspond, the
+       BGP speaker MUST reject the connection using the Role Mismatch
+       Notification (code 2, subcode 11).";
+    reference
+      "RFC 9234: Route Leak Prevention and Detection Using Roles in
+       UPDATE and OPEN Messages, Section 4.2.";
+  }
+
+  identity bgp-notification-update-message-error {
+    base bgp-notification;
+    description
+      "All errors detected while processing the UPDATE message MUST
+       be indicated by sending the NOTIFICATION message with the
+       Error Code UPDATE Message Error.
+
+      The value of the 'UPDATE Message Error' Error code is 3.";
+    reference
+      "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 6.3.";
+  }
+
+  identity bgp-update-unspecific {
+    base bgp-notification-update-message-error;
+    description
+      "If no appropriate Error Subcode is defined, then a zero
+       (Unspecific) value is used for the Error Subcode field.
+
+       The value of the 'Unspecific Error' subcode is 0.";
+    reference
+      "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 4.5.";
+  }
+
+  identity bgp-update-malformed-attribute-list {
+    base bgp-notification-update-message-error;
+    description
+      "Error checking of an UPDATE message begins by examining the
+       path attributes.  If the Withdrawn Routes Length or Total
+       Attribute Length is too large (i.e., if Withdrawn Routes
+       Length + Total Attribute Length + 23 exceeds the message
+       Length), then the Error Subcode MUST be set to Malformed
+       Attribute List.
+
+       If any attribute appears more than once in the UPDATE message,
+       then the Error Subcode MUST be set to Malformed Attribute
+       List.
+
+       The value of the 'Malformed Attribute List' Error subcode is
+       1.";
+    reference
+      "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 6.3.";
+  }
+
+  identity bgp-update-unrecognized-well-known-attribute {
+    base bgp-notification-update-message-error;
+    description
+      "If any of the well-known mandatory attributes are not
+       recognized, then the Error Subcode MUST be set to Unrecognized
+       Well-known Attribute.  The Data field MUST contain the
+       unrecognized attribute (type, length, and value).
+
+       The value of the 'Unrecognized Well-known Attribute' Error
+       subcode is 2.";
+    reference
+      "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 6.3.";
+  }
+
+  identity bgp-update-missing-well-known-attribute {
+    base bgp-notification-update-message-error;
+    description
+      "If any of the well-known mandatory attributes are not present,
+       then the Error Subcode MUST be set to Missing Well-known
+       Attribute.  The Data field MUST contain the Attribute Type
+       Code of the missing, well-known attribute.
+
+       The value of the 'Missing Well-known Attribute' Error subcode
+       is 3.";
+    reference
+      "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 6.3.";
+  }
+
+  identity bgp-update-attribute-flags-error {
+    base bgp-notification-update-message-error;
+    description
+      "If any recognized attribute has Attribute Flags that conflict
+       with the Attribute Type Code, then the Error Subcode MUST be
+       set to Attribute Flags Error.  The Data field MUST contain the
+       erroneous attribute (type, length, and value).
+
+       The value of the 'Attribute Flags Error' Error subcode is 4.";
+    reference
+      "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 6.3.";
+  }
+
+  identity bgp-update-attribute-length-error {
+    base bgp-notification-update-message-error;
+    description
+      "If any recognized attribute has an Attribute Length that
+       conflicts with the expected length (based on the attribute
+       type code), then the Error Subcode MUST be set to Attribute
+       Length Error.  The Data field MUST contain the erroneous
+       attribute (type, length, and value).
+
+       The value of the 'Attribute Length Error' Error subcode is
+       5.";
+    reference
+      "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 6.3.";
+  }
+
+  identity bgp-update-invalid-origin-attribute {
+    base bgp-notification-update-message-error;
+    description
+      "If the ORIGIN attribute has an undefined value, then the Error
+       Sub-code MUST be set to Invalid Origin Attribute.  The Data
+       field MUST contain the unrecognized attribute (type, length,
+       and value).
+
+       The value of the 'Invalid ORIGIN Attribute' Error subcode is
+       6.";
+    reference
+      "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 6.3.";
+  }
+
+  identity bgp-update-invalid-next-hop-attribute {
+    base bgp-notification-update-message-error;
+    description
+      "If the NEXT_HOP attribute field is syntactically incorrect,
+       then the Error Subcode MUST be set to Invalid NEXT_HOP
+       Attribute.  The Data field MUST contain the incorrect
+       attribute (type, length, and value).  Syntactic correctness
+       means that the NEXT_HOP attribute represents a valid IP host
+       address.
+
+       The value of the 'Invalid NEXT_HOP Attribute' Error subcode is
+       8.";
+    reference
+      "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 6.3.";
+  }
+
+  identity bgp-open-optional-attribute-error {
+    base bgp-notification-update-message-error;
+    description
+      "If an optional attribute is recognized, then the value of this
+       attribute MUST be checked.  If an error is detected, the
+       attribute MUST be discarded, and the Error Subcode MUST be set
+       to Optional Attribute Error.  The Data field MUST contain the
+       attribute (type, length, and value).
+
+       The value of the 'Optional Attribute Error' Error subcode is
+       9.";
+    reference
+      "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 6.3.";
+  }
+
+  identity bgp-open-invalid-network-field {
+    base bgp-notification-update-message-error;
+    description
+      "The NLRI field in the UPDATE message is checked for syntactic
+      validity.  If the field is syntactically incorrect, then the
+      Error Subcode MUST be set to Invalid Network Field.
+
+      The value of the 'Invalid Network Field' Error subcode is 10.";
+    reference
+      "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 6.3.";
+  }
+
+  identity bgp-open-malformed-as-path {
+    base bgp-notification-update-message-error;
+    description
+      "The AS_PATH attribute is checked for syntactic correctness.
+       If the path is syntactically incorrect, then the Error Subcode
+       MUST be set to Malformed AS_PATH.
+
+       If the UPDATE message is received from an external peer, the
+       local system MAY check whether the leftmost (with respect to
+       the position of octets in the protocol message) AS in the
+       AS_PATH attribute is equal to the autonomous system number of
+       the peer that sent the message.  If the check determines this
+       is not the case, the Error Subcode MUST be set to Malformed
+       AS_PATH.
+
+       The value of the 'Malformed AS_PATH' Error subcode is 11.";
+    reference
+      "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 6.3.";
+  }
+
+  identity bgp-notification-hold-timer-expired-error {
+    base bgp-notification;
+    description
+      "If a system does not receive successive KEEPALIVE, UPDATE,
+       and/or NOTIFICATION messages within the period specified in
+       the Hold Time field of the OPEN message, then the NOTIFICATION
+       message with the Hold Timer Expired Error Code is sent and the
+       BGP connection is closed.
+
+       The value of the 'Hold Timer Expired' Error code is 4.";
+    reference
+      "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 6.5.";
+  }
+
+  identity bgp-hold-timer-expired-unspecific {
+    base bgp-notification-hold-timer-expired-error;
+    description
+      "If no appropriate Error Subcode is defined, then a zero
+       (Unspecific) value is used for the Error Subcode field.
+
+       The value of the 'Unspecific Error' subcode is 0.";
+    reference
+      "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 4.5.";
+  }
+
+
+  identity bgp-notification-fsm-error {
+    base bgp-notification;
+    description
+      "Any error detected by the BGP Finite State Machine (e.g.,
+       receipt of an unexpected event) is indicated by sending the
+       NOTIFICATION message with the Error Code Finite State Machine
+       Error.
+
+       The value of the 'Finite State Machine Error' Error code is
+       5.";
+    reference
+      "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 6.6.
+       RFC 6608: Subcodes for BGP Finite State Machine Error.";
+  }
+
+  identity bgp-fsm-error-unspecified {
+    base bgp-notification-fsm-error;
+    description
+      "If no appropriate Error Subcode is defined, then a zero
+       (Unspecific) value is used for the Error Subcode field.
+
+       The value of the 'Unspecific Error' subcode is 0.";
+    reference
+      "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 4.5.
+       RFC 6608: Subcodes for BGP Finite State Machine Error, Section
+       3.";
+  }
+
+  identity bgp-fsm-error-unexpected-in-opensent {
+    base bgp-notification-fsm-error;
+    description
+      "If a BGP speaker receives an unexpected message (e.g.,
+       KEEPALIVE/ UPDATE/ROUTE-REFRESH message) on a session in
+       OpenSent state, it MUST send to the neighbor a NOTIFICATION
+       message with the Error Code Finite State Machine Error and the
+       Error Subcode 'Receive Unexpected Message in OpenSent State'.
+       The Data field is a 1-octet, unsigned integer that indicates
+       the type of the unexpected message.
+
+       The value of the 'Receive Unexpected Message in OpenSent
+       State' Error subcode is 1.";
+    reference
+      "RFC 6608: Subcodes for BGP Finite State Machine Error, Section
+       4.";
+  }
+
+  identity bgp-fsm-error-unexpected-in-openconfirm {
+    base bgp-notification-fsm-error;
+    description
+      "If a BGP speaker receives an unexpected message (e.g.,
+       OPEN/UPDATE/ ROUTE-REFRESH message) on a session in
+       OpenConfirm state, it MUST send a NOTIFICATION message with
+       the Error Code Finite State Machine Error and the Error
+       Subcode 'Receive Unexpected Message in OpenConfirm State' to
+       the neighbor.  The Data field is a 1-octet, unsigned integer
+       that indicates the type of the unexpected message.
+
+       The value of the 'Receive Unexpected Message in OpenConfirm
+       State' Error subcode is 2.";
+    reference
+      "RFC 6608: Subcodes for BGP Finite State Machine Error, Section
+       4.";
+  }
+
+  identity bgp-fsm-error-unexpected-in-established {
+    base bgp-notification-fsm-error;
+    description
+      "If a BGP speaker receives an unexpected message (e.g., OPEN
+       message) on a session in Established State, it MUST send to
+       the neighbor a NOTIFICATION message with the Error Code Finite
+       State Machine Error and the Error Subcode 'Receive Unexpected
+       Message in Established State'.  The Data field is a 1-octet,
+       unsigned integer that indicates the type of the unexpected
+       message.
+
+       The value of the 'Receive Unexpected Message in Established
+       State' Error subcode is 3.";
+    reference
+      "RFC 6608: Subcodes for BGP Finite State Machine Error, Section
+       4.";
+  }
+
+  identity bgp-notification-cease {
+    base bgp-notification;
+    description
+      "In the absence of any fatal errors (that are indicated in this
+       section), a BGP peer MAY choose, at any given time, to close
+       its BGP connection by sending the NOTIFICATION message with
+       the Error Code Cease.  However, the Cease NOTIFICATION message
+       MUST NOT be used when a fatal error indicated by this section
+       does exist.
+
+       The value of the 'Cease' Error code is 6.";
+    reference
+      "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 6.7.";
+  }
+
+  identity bgp-cease-max-prefixes {
+    base bgp-notification-cease;
+    description
+      "From RFC 4271, Section 6.7:
+       A BGP speaker MAY support the ability to impose a
+       locally-configured, upper bound on the number of address
+       prefixes the speaker is willing to accept from a neighbor.
+       When the upper bound is reached, the speaker, under control of
+       local configuration, either (a) discards new address prefixes
+       from the neighbor (while maintaining the BGP connection with
+       the neighbor), or (b) terminates the BGP connection with the
+       neighbor.  If the BGP speaker decides to terminate its BGP
+       connection with a neighbor because the number of address
+       prefixes received from the neighbor exceeds the
+       locally-configured, upper bound, then the speaker MUST send
+       the neighbor a NOTIFICATION message with the Error Code
+       Cease.
+
+       From RFC 4486:
+       If a BGP speaker decides to terminate its peering with a
+       neighbor because the number of address prefixes received from
+       the neighbor exceeds a locally configured upper bound (as
+       described in [BGP-4]), then the speaker MUST send to the
+       neighbor a NOTIFICATION message with the Error Code Cease and
+       the Error Subcode 'Maximum Number of Prefixes Reached'.  The
+       message MAY optionally include the Address Family information
+       [BGP-MP] and the upper bound in the 'Data' field, as shown in
+       Figure 1, where the meaning and use of the <AFI, SAFI> tuple
+       is the same as defined in [BGP-MP], Section 7.
+
+       The value of the 'Maximum Number of Prefixes Reached' Error
+       subcode is 1.";
+    reference
+      "RFC 4486: Subcodes for BGP Cease Notification Message, Section
+       4.";
+  }
+
+  identity bgp-cease-admin-shutdown {
+    base bgp-notification-cease;
+    description
+      "If a BGP speaker decides to administratively shut down its
+       peering with a neighbor, then the speaker SHOULD send a
+       NOTIFICATION message with the Error Code Cease and the Error
+       Subcode 'Administrative Shutdown'.
+
+       The value of the 'Administrative Shutdown' Error subcode is
+       2.";
+    reference
+      "RFC 4486: Subcodes for BGP Cease Notification Message, Section
+       4.";
+  }
+  
+  identity bgp-cease-peer-deconfigured {
+    base bgp-notification-cease;
+    description
+      "If a BGP speaker decides to de-configure a peer, then the
+       speaker SHOULD send a NOTIFICATION message with the Error Code
+       Cease and the Error Subcode 'Peer De-configured'.
+
+       The value of the 'Peer De-configured' Error subcode is 3.";
+    reference
+      "RFC 4486: Subcodes for BGP Cease Notification Message, Section
+       4.";
+  }
+
+  identity bgp-cease-admin-reset {
+    base bgp-notification-cease;
+    description
+      "If a BGP speaker decides to administratively reset the peering
+       with a neighbor, then the speaker SHOULD send a NOTIFICATION
+       message with the Error Code Cease and the Error Subcode
+       'Administrative Reset'.
+
+       The value of the 'Administrative Reset' Error subcode is 4.";
+     reference
+      "RFC 4486: Subcodes for BGP Cease Notification Message, Section
+       4.";
+  }
+
+  identity bgp-cease-connection-rejected {
+    base bgp-notification-cease;
+    description
+      "If a BGP speaker decides to disallow a BGP connection (e.g.,
+       the peer is not configured locally) after the speaker accepts
+       a transport protocol connection, then the BGP speaker SHOULD
+       send a NOTIFICATION message with the Error Code Cease and the
+       Error Subcode 'Connection Rejected'.
+
+       The value of the 'Connection Rejected' Error subcode is 5.";
+    reference
+      "RFC 4486: Subcodes for BGP Cease Notification Message, Section
+       4.";
+  }
+
+  identity bgp-cease-other-configuration-change {
+    base bgp-notification-cease;
+    description
+      "If a BGP speaker decides to administratively reset the peering
+       with a neighbor due to a configuration change other than the
+       ones described above, then the speaker SHOULD send a
+       NOTIFICATION message with the Error Code Cease and the Error
+       Subcode 'Other Configuration Change'.
+
+       The value of the 'Other Configuration Change' Error subcode is
+       6.";
+    reference
+      "RFC 4486: Subcodes for BGP Cease Notification Message, Section
+       4.";
+  }
+
+  identity bgp-cease-connection-collision {
+    base bgp-notification-cease;
+    description
+      "If a BGP speaker decides to send a NOTIFICATION message with
+       the Error Code Cease as a result of the collision resolution
+       procedure (as described in [BGP-4]), then the subcode SHOULD
+       be set to 'Connection Collision Resolution'.
+
+       The value of the 'Connection Collision Resolution' Error
+       subcode is 7.";
+    reference
+      "RFC 4486: Subcodes for BGP Cease Notification Message, Section
+       4.";
+  }
+  
+  identity bgp-cease-out-of-resources {
+    base bgp-notification-cease;
+    description
+      "If a BGP speaker runs out of resources (e.g., memory) and
+       decides to reset a session, then the speaker MAY send a
+       NOTIFICATION message with the Error Code Cease and the Error
+       Subcode 'Out of Resources'.
+
+       The value of the 'Out of Resources' Error subcode is 8.";
+    reference
+      "RFC 4486: Subcodes for BGP Cease Notification Message, Section
+       4.";
+  }
+
+  identity bgp-cease-hard-reset {
+    base bgp-notification-cease;
+    description
+      "[RFC 8538] defines a new subcode for BGP Cease NOTIFICATION
+       messages, called the Hard Reset subcode.  The value of this
+       subcode is [9].  In this document, a BGP Cease NOTIFICATION
+       message with the Hard Reset subcode is referred to as a 'Hard
+       Reset message' or simply as a 'Hard Reset'.
+
+       The value of the 'Hard Reset' Error subcode is 9.";
+    reference
+      "RFC 8538: Notification Message Support for BGP Graceful
+       Restart, Section 3.";
+  }
+
+  identity bgp-cease-bfd-down {
+    base bgp-notification-cease;
+    description
+      "When a BGP session is terminated due to a BFD session going
+       into the Down state, the BGP Speaker SHOULD send a
+       NOTIFICATION message with the Error Code Cease and the Error
+       Subcode 'BFD Down'.
+
+       The value of the 'BFD Down' Error subocde is 10.";
+    reference
+      "draft-ietf-idr-bfd-subcode-05: A BGP Cease Notification
+      Subcode For Bidirectional Forwarding Detection (BFD), Section
+      2.";
+  }
+
+  identity bgp-notification-route-refresh-message-error {
+    base bgp-notification;
+    description
+      "The ROUTE-REFRESH Message Error code was defined in RFC 7313.
+
+      The value of the 'ROUTE-REFRESH Message Error' Error code is
+      7.";
+    reference
+      "RFC 7313: Enhanced Route Refresh Capability for BGP-4, Section
+       5.";
+  }
+
+  identity bgp-route-refresh-reserved {
+    base bgp-notification-route-refresh-message-error;
+    description
+      "If no appropriate Error Subcode is defined, then a zero
+       (Unspecific) value is used for the Error Subcode field.
+
+       The value of the 'Unspecific Error' subcode is 0.";
+    reference
+      "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 4.5.
+       RFC 7313: Enhanced Route Refresh Capability for BGP-4, Section
+       6.";
+  }
+
+  identity bgp-route-refresh-invalid-message-length {
+    base bgp-notification-route-refresh-message-error;
+    description
+      "If the length, excluding the fixed-size message header, of the
+       received ROUTE-REFRESH message with Message Subtype 1 and 2 is
+       not 4, then the BGP speaker MUST send a NOTIFICATION message
+       with the Error Code of 'ROUTE-REFRESH Message Error' and the
+       subcode of 'Invalid Message Length'.  The Data field of the
+       NOTIFICATION message MUST contain the complete ROUTE-REFRESH
+       message.
+
+       The value of the 'Invalid Message Length' Error subcode is
+       1.";
+    reference
+      "RFC 7313: Enhanced Route Refresh Capability for BGP-4, Section
+       5.";
+  }
+}

--- a/src/yang/iana-bgp-notification.yang
+++ b/src/yang/iana-bgp-notification.yang
@@ -53,7 +53,7 @@ module iana-bgp-notification {
     description
       "Initial Version";
     reference
-      "RFC XXX, BGP Model for Service Provider Network.";
+      "RFC XXXX: YANG Model for Border Gateway Protocol (BGP-4).";
   }
 
 

--- a/src/yang/iana-bgp-notification.yang
+++ b/src/yang/iana-bgp-notification.yang
@@ -62,7 +62,7 @@ module iana-bgp-notification {
       "Base identity for BGP NOTIFICATION state.";
   }
 
-  identity bgp-notification-message-header-error {
+  identity message-header-error {
     base bgp-notification;
     description
       "All errors detected while processing the Message Header MUST
@@ -74,8 +74,8 @@ module iana-bgp-notification {
       "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 6.1.";
   }
 
-  identity bgp-message-header-unspecific {
-    base bgp-notification-message-header-error;
+  identity message-header-unspecific {
+    base message-header-error;
     description
       "If no appropriate Error Subcode is defined, then a zero
        (Unspecific) value is used for the Error Subcode field.
@@ -85,8 +85,8 @@ module iana-bgp-notification {
       "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 4.5.";
   }
 
-  identity bgp-message-header-connection-not-synchronized {
-    base bgp-notification-message-header-error;
+  identity message-header-connection-not-synchronized {
+    base message-header-error;
     description
       "If the Marker field of the message header is not as expected,
        then a synchronization error has occurred and the Error
@@ -98,8 +98,8 @@ module iana-bgp-notification {
       "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 6.1.";
   }
 
-  identity bgp-message-header-bad-message-length {
-    base bgp-notification-message-header-error;
+  identity message-header-bad-message-length {
+    base message-header-error;
     description
       "If at least one of the following is true:
 
@@ -126,8 +126,8 @@ module iana-bgp-notification {
       "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 6.1.";
   }
 
-  identity bgp-message-header-bad-message-type {
-    base bgp-notification-message-header-error;
+  identity message-header-bad-message-type {
+    base message-header-error;
     description
       "If the Type field of the message header is not recognized,
        then the Error Subcode MUST be set to Bad Message Type.  The
@@ -138,7 +138,7 @@ module iana-bgp-notification {
       "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 6.1.";
   }
 
-  identity bgp-notification-open-message-error {
+  identity open-message-error {
     base bgp-notification;
     description
       "All errors detected while processing the OPEN message MUST be
@@ -150,8 +150,8 @@ module iana-bgp-notification {
       "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 6.2.";
   }
 
-  identity bgp-open-message-unspecific {
-    base bgp-notification-open-message-error;
+  identity open-message-unspecific {
+    base open-message-error;
     description
       "From Section 4.5:
        If no appropriate Error Subcode is defined, then a zero
@@ -168,8 +168,8 @@ module iana-bgp-notification {
        RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 6.2.";
   }
 
-  identity bgp-open-unsupported-version-number {
-    base bgp-notification-open-message-error;
+  identity open-unsupported-version-number {
+    base open-message-error;
     description
       "If the version number in the Version field of the received
        OPEN message is not supported, then the Error Subcode MUST be
@@ -187,8 +187,8 @@ module iana-bgp-notification {
       "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 6.2.";
   }
 
-  identity bgp-open-bad-peer-as {
-    base bgp-notification-open-message-error;
+  identity open-bad-peer-as {
+    base open-message-error;
     description
       "If the Autonomous System field of the OPEN message is
        unacceptable, then the Error Subcode MUST be set to Bad Peer
@@ -200,8 +200,8 @@ module iana-bgp-notification {
       "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 6.2.";
   }
 
-  identity bgp-open-bad-bgp-id {
-    base bgp-notification-open-message-error;
+  identity open-bad-bgp-id {
+    base open-message-error;
     description
       "From RFC 4271, Section 6.2:
        If the BGP Identifier field of the OPEN message is
@@ -226,8 +226,8 @@ module iana-bgp-notification {
        BGP-4., Section 2.2.";
   }
 
-  identity bgp-open-unsupported-optional-parameter {
-    base bgp-notification-open-message-error;
+  identity open-unsupported-optional-parameter {
+    base open-message-error;
     description
       "If one of the Optional Parameters in the OPEN message is not
       recognized, then the Error Subcode MUST be set to Unsupported
@@ -239,8 +239,8 @@ module iana-bgp-notification {
       "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 6.2.";
   }
 
-  identity bgp-open-unacceptable-hold-time {
-    base bgp-notification-open-message-error;
+  identity open-unacceptable-hold-time {
+    base open-message-error;
     description
       "If the Hold Time field of the OPEN message is unacceptable,
        then the Error Subcode MUST be set to Unacceptable Hold Time.
@@ -255,8 +255,8 @@ module iana-bgp-notification {
       "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 6.2.";
   }
 
-  identity bgp-open-unsupported-capability {
-    base bgp-notification-open-message-error;
+  identity open-unsupported-capability {
+    base open-message-error;
     description
       "If a BGP speaker that supports a certain capability determines
        that its peer doesn't support this capability, the speaker MAY
@@ -276,8 +276,8 @@ module iana-bgp-notification {
       "RFC 5492: Capabilities Advertisement with BGP-4, Section 3.";
   }
 
-  identity bgp-open-role-mismatch {
-    base bgp-notification-open-message-error;
+  identity open-role-mismatch {
+    base open-message-error;
     description
       "If the BGP Role Capability is advertised, and one is also
        received from the peer, the Roles MUST correspond to the
@@ -289,7 +289,7 @@ module iana-bgp-notification {
        UPDATE and OPEN Messages, Section 4.2.";
   }
 
-  identity bgp-notification-update-message-error {
+  identity update-message-error {
     base bgp-notification;
     description
       "All errors detected while processing the UPDATE message MUST
@@ -301,8 +301,8 @@ module iana-bgp-notification {
       "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 6.3.";
   }
 
-  identity bgp-update-unspecific {
-    base bgp-notification-update-message-error;
+  identity update-unspecific {
+    base update-message-error;
     description
       "If no appropriate Error Subcode is defined, then a zero
        (Unspecific) value is used for the Error Subcode field.
@@ -312,8 +312,8 @@ module iana-bgp-notification {
       "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 4.5.";
   }
 
-  identity bgp-update-malformed-attribute-list {
-    base bgp-notification-update-message-error;
+  identity update-malformed-attribute-list {
+    base update-message-error;
     description
       "Error checking of an UPDATE message begins by examining the
        path attributes.  If the Withdrawn Routes Length or Total
@@ -332,8 +332,8 @@ module iana-bgp-notification {
       "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 6.3.";
   }
 
-  identity bgp-update-unrecognized-well-known-attribute {
-    base bgp-notification-update-message-error;
+  identity update-unrecognized-well-known-attribute {
+    base update-message-error;
     description
       "If any of the well-known mandatory attributes are not
        recognized, then the Error Subcode MUST be set to Unrecognized
@@ -346,8 +346,8 @@ module iana-bgp-notification {
       "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 6.3.";
   }
 
-  identity bgp-update-missing-well-known-attribute {
-    base bgp-notification-update-message-error;
+  identity update-missing-well-known-attribute {
+    base update-message-error;
     description
       "If any of the well-known mandatory attributes are not present,
        then the Error Subcode MUST be set to Missing Well-known
@@ -360,8 +360,8 @@ module iana-bgp-notification {
       "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 6.3.";
   }
 
-  identity bgp-update-attribute-flags-error {
-    base bgp-notification-update-message-error;
+  identity update-attribute-flags-error {
+    base update-message-error;
     description
       "If any recognized attribute has Attribute Flags that conflict
        with the Attribute Type Code, then the Error Subcode MUST be
@@ -373,8 +373,8 @@ module iana-bgp-notification {
       "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 6.3.";
   }
 
-  identity bgp-update-attribute-length-error {
-    base bgp-notification-update-message-error;
+  identity update-attribute-length-error {
+    base update-message-error;
     description
       "If any recognized attribute has an Attribute Length that
        conflicts with the expected length (based on the attribute
@@ -388,8 +388,8 @@ module iana-bgp-notification {
       "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 6.3.";
   }
 
-  identity bgp-update-invalid-origin-attribute {
-    base bgp-notification-update-message-error;
+  identity update-invalid-origin-attribute {
+    base update-message-error;
     description
       "If the ORIGIN attribute has an undefined value, then the Error
        Sub-code MUST be set to Invalid Origin Attribute.  The Data
@@ -402,8 +402,8 @@ module iana-bgp-notification {
       "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 6.3.";
   }
 
-  identity bgp-update-invalid-next-hop-attribute {
-    base bgp-notification-update-message-error;
+  identity update-invalid-next-hop-attribute {
+    base update-message-error;
     description
       "If the NEXT_HOP attribute field is syntactically incorrect,
        then the Error Subcode MUST be set to Invalid NEXT_HOP
@@ -418,8 +418,8 @@ module iana-bgp-notification {
       "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 6.3.";
   }
 
-  identity bgp-open-optional-attribute-error {
-    base bgp-notification-update-message-error;
+  identity open-optional-attribute-error {
+    base update-message-error;
     description
       "If an optional attribute is recognized, then the value of this
        attribute MUST be checked.  If an error is detected, the
@@ -433,8 +433,8 @@ module iana-bgp-notification {
       "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 6.3.";
   }
 
-  identity bgp-open-invalid-network-field {
-    base bgp-notification-update-message-error;
+  identity open-invalid-network-field {
+    base update-message-error;
     description
       "The NLRI field in the UPDATE message is checked for syntactic
       validity.  If the field is syntactically incorrect, then the
@@ -445,8 +445,8 @@ module iana-bgp-notification {
       "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 6.3.";
   }
 
-  identity bgp-open-malformed-as-path {
-    base bgp-notification-update-message-error;
+  identity open-malformed-as-path {
+    base update-message-error;
     description
       "The AS_PATH attribute is checked for syntactic correctness.
        If the path is syntactically incorrect, then the Error Subcode
@@ -465,7 +465,7 @@ module iana-bgp-notification {
       "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 6.3.";
   }
 
-  identity bgp-notification-hold-timer-expired-error {
+  identity hold-timer-expired-error {
     base bgp-notification;
     description
       "If a system does not receive successive KEEPALIVE, UPDATE,
@@ -479,8 +479,8 @@ module iana-bgp-notification {
       "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 6.5.";
   }
 
-  identity bgp-hold-timer-expired-unspecific {
-    base bgp-notification-hold-timer-expired-error;
+  identity timer-expired-unspecific {
+    base hold-timer-expired-error;
     description
       "If no appropriate Error Subcode is defined, then a zero
        (Unspecific) value is used for the Error Subcode field.
@@ -491,7 +491,7 @@ module iana-bgp-notification {
   }
 
 
-  identity bgp-notification-fsm-error {
+  identity fsm-error {
     base bgp-notification;
     description
       "Any error detected by the BGP Finite State Machine (e.g.,
@@ -506,8 +506,8 @@ module iana-bgp-notification {
        RFC 6608: Subcodes for BGP Finite State Machine Error.";
   }
 
-  identity bgp-fsm-error-unspecified {
-    base bgp-notification-fsm-error;
+  identity fsm-error-unspecified {
+    base fsm-error;
     description
       "If no appropriate Error Subcode is defined, then a zero
        (Unspecific) value is used for the Error Subcode field.
@@ -519,8 +519,8 @@ module iana-bgp-notification {
        3.";
   }
 
-  identity bgp-fsm-error-unexpected-in-opensent {
-    base bgp-notification-fsm-error;
+  identity fsm-error-unexpected-in-opensent {
+    base fsm-error;
     description
       "If a BGP speaker receives an unexpected message (e.g.,
        KEEPALIVE/ UPDATE/ROUTE-REFRESH message) on a session in
@@ -537,8 +537,8 @@ module iana-bgp-notification {
        4.";
   }
 
-  identity bgp-fsm-error-unexpected-in-openconfirm {
-    base bgp-notification-fsm-error;
+  identity fsm-error-unexpected-in-openconfirm {
+    base fsm-error;
     description
       "If a BGP speaker receives an unexpected message (e.g.,
        OPEN/UPDATE/ ROUTE-REFRESH message) on a session in
@@ -555,8 +555,8 @@ module iana-bgp-notification {
        4.";
   }
 
-  identity bgp-fsm-error-unexpected-in-established {
-    base bgp-notification-fsm-error;
+  identity fsm-error-unexpected-in-established {
+    base fsm-error;
     description
       "If a BGP speaker receives an unexpected message (e.g., OPEN
        message) on a session in Established State, it MUST send to
@@ -573,7 +573,7 @@ module iana-bgp-notification {
        4.";
   }
 
-  identity bgp-notification-cease {
+  identity cease {
     base bgp-notification;
     description
       "In the absence of any fatal errors (that are indicated in this
@@ -588,8 +588,8 @@ module iana-bgp-notification {
       "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 6.7.";
   }
 
-  identity bgp-cease-max-prefixes {
-    base bgp-notification-cease;
+  identity cease-max-prefixes {
+    base cease;
     description
       "From RFC 4271, Section 6.7:
        A BGP speaker MAY support the ability to impose a
@@ -625,8 +625,8 @@ module iana-bgp-notification {
        4.";
   }
 
-  identity bgp-cease-admin-shutdown {
-    base bgp-notification-cease;
+  identity cease-admin-shutdown {
+    base cease;
     description
       "If a BGP speaker decides to administratively shut down its
        peering with a neighbor, then the speaker SHOULD send a
@@ -640,8 +640,8 @@ module iana-bgp-notification {
        4.";
   }
   
-  identity bgp-cease-peer-deconfigured {
-    base bgp-notification-cease;
+  identity cease-peer-deconfigured {
+    base cease;
     description
       "If a BGP speaker decides to de-configure a peer, then the
        speaker SHOULD send a NOTIFICATION message with the Error Code
@@ -653,8 +653,8 @@ module iana-bgp-notification {
        4.";
   }
 
-  identity bgp-cease-admin-reset {
-    base bgp-notification-cease;
+  identity cease-admin-reset {
+    base cease;
     description
       "If a BGP speaker decides to administratively reset the peering
        with a neighbor, then the speaker SHOULD send a NOTIFICATION
@@ -667,8 +667,8 @@ module iana-bgp-notification {
        4.";
   }
 
-  identity bgp-cease-connection-rejected {
-    base bgp-notification-cease;
+  identity cease-connection-rejected {
+    base cease;
     description
       "If a BGP speaker decides to disallow a BGP connection (e.g.,
        the peer is not configured locally) after the speaker accepts
@@ -682,8 +682,8 @@ module iana-bgp-notification {
        4.";
   }
 
-  identity bgp-cease-other-configuration-change {
-    base bgp-notification-cease;
+  identity cease-other-configuration-change {
+    base cease;
     description
       "If a BGP speaker decides to administratively reset the peering
        with a neighbor due to a configuration change other than the
@@ -698,8 +698,8 @@ module iana-bgp-notification {
        4.";
   }
 
-  identity bgp-cease-connection-collision {
-    base bgp-notification-cease;
+  identity cease-connection-collision {
+    base cease;
     description
       "If a BGP speaker decides to send a NOTIFICATION message with
        the Error Code Cease as a result of the collision resolution
@@ -713,8 +713,8 @@ module iana-bgp-notification {
        4.";
   }
   
-  identity bgp-cease-out-of-resources {
-    base bgp-notification-cease;
+  identity cease-out-of-resources {
+    base cease;
     description
       "If a BGP speaker runs out of resources (e.g., memory) and
        decides to reset a session, then the speaker MAY send a
@@ -727,8 +727,8 @@ module iana-bgp-notification {
        4.";
   }
 
-  identity bgp-cease-hard-reset {
-    base bgp-notification-cease;
+  identity cease-hard-reset {
+    base cease;
     description
       "[RFC 8538] defines a new subcode for BGP Cease NOTIFICATION
        messages, called the Hard Reset subcode.  The value of this
@@ -742,8 +742,8 @@ module iana-bgp-notification {
        Restart, Section 3.";
   }
 
-  identity bgp-cease-bfd-down {
-    base bgp-notification-cease;
+  identity cease-bfd-down {
+    base cease;
     description
       "When a BGP session is terminated due to a BFD session going
        into the Down state, the BGP Speaker SHOULD send a
@@ -757,7 +757,7 @@ module iana-bgp-notification {
       2.";
   }
 
-  identity bgp-notification-route-refresh-message-error {
+  identity route-refresh-message-error {
     base bgp-notification;
     description
       "The ROUTE-REFRESH Message Error code was defined in RFC 7313.
@@ -769,8 +769,8 @@ module iana-bgp-notification {
        5.";
   }
 
-  identity bgp-route-refresh-reserved {
-    base bgp-notification-route-refresh-message-error;
+  identity route-refresh-reserved {
+    base route-refresh-message-error;
     description
       "If no appropriate Error Subcode is defined, then a zero
        (Unspecific) value is used for the Error Subcode field.
@@ -782,8 +782,8 @@ module iana-bgp-notification {
        6.";
   }
 
-  identity bgp-route-refresh-invalid-message-length {
-    base bgp-notification-route-refresh-message-error;
+  identity route-refresh-invalid-message-length {
+    base route-refresh-message-error;
     description
       "If the length, excluding the fixed-size message header, of the
        received ROUTE-REFRESH message with Message Subtype 1 and 2 is

--- a/src/yang/ietf-bgp.yang
+++ b/src/yang/ietf-bgp.yang
@@ -26,7 +26,7 @@ module ietf-bgp {
   import iana-bgp-notification {
     prefix bn;
     reference
-      "RFC XXXX, BGP YANG Model for Service Provider Network.";
+      "RFC XXXX: YANG Model for Border Gateway Protocol (BGP-4).";
   }
   import iana-bgp-types {
     prefix bt;
@@ -254,7 +254,8 @@ module ietf-bgp {
         "The timestamp indicates the time that a BGP
          NOTIFICATION message was last handled.";
       reference
-        "RFC 4271, Section 4.5.";
+        "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section
+         4.5.";
     }
     leaf last-error {
       type identityref {
@@ -267,7 +268,8 @@ module ietf-bgp {
          last-error-subcode will have the information received
          in the NOTIFICATION PDU.";
       reference
-        "RFC 4271, Section 4.5.";
+        "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section
+         4.5.";
     }
     leaf last-error-code {
       type uint8;
@@ -275,7 +277,8 @@ module ietf-bgp {
         "The last NOTIFICATION Error code for the peer on
          this connection.";
       reference
-        "RFC 4271, Section 4.5.";
+        "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section
+         4.5.";
     }
     leaf last-error-subcode {
       type uint8;
@@ -283,7 +286,8 @@ module ietf-bgp {
         "The last NOTIFICATION Error subcode for the peer on
          this connection.";
       reference
-        "RFC 4271, Section 4.5.";
+        "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section
+         4.5.";
     }
   }
   grouping bgp-errors-common-data {

--- a/src/yang/ietf-bgp.yang
+++ b/src/yang/ietf-bgp.yang
@@ -265,10 +265,10 @@ module ietf-bgp {
         "The last NOTIFICATION error for the peer on this
          connection.  If no identity is registered for the
          Error code / Error subcode, this leaf contains the most
-	 applicable identity for the BGP NOTIFICATION base code.
+         applicable identity for the BGP NOTIFICATION base code.
 
-	 The last-error-code and last-error-subcode will always have
-	 the information received in the NOTIFICATION PDU.";
+         The last-error-code and last-error-subcode will always have
+         the information received in the NOTIFICATION PDU.";
       reference
         "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section
          4.5.";

--- a/src/yang/ietf-bgp.yang
+++ b/src/yang/ietf-bgp.yang
@@ -264,9 +264,11 @@ module ietf-bgp {
       description
         "The last NOTIFICATION error for the peer on this
          connection.  If no identity is registered for the
-         Error code / Error subcode, the last-error-code and
-         last-error-subcode will have the information received
-         in the NOTIFICATION PDU.";
+         Error code / Error subcode, this leaf contains the most
+	 applicable identity for the BGP NOTIFICATION base code.
+
+	 The last-error-code and last-error-subcode will always have
+	 the information received in the NOTIFICATION PDU.";
       reference
         "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section
          4.5.";

--- a/src/yang/ietf-bgp.yang
+++ b/src/yang/ietf-bgp.yang
@@ -23,6 +23,11 @@ module ietf-bgp {
     reference
       "RFC 8343, A YANG Data Model for Interface Management.";
   }
+  import iana-bgp-notification {
+    prefix bn;
+    reference
+      "RFC XXXX, BGP YANG Model for Service Provider Network.";
+  }
   import iana-bgp-types {
     prefix bt;
     reference
@@ -236,6 +241,66 @@ module ietf-bgp {
     uses structure-neighbor-group-add-paths;
     uses bgp-neighbor-use-multiple-paths;
     uses rt-pol:apply-policy-group;
+  }
+
+  grouping bgp-errors-common {
+    description
+      "BGP NOTIFICATION state that is common in the sent and received
+       direction.";
+      
+    leaf last-notification {
+      type yang:date-and-time;
+      description
+        "The timestamp indicates the time that a BGP
+         NOTIFICATION message was last handled.";
+      reference
+        "RFC 4271, Section 4.5.";
+    }
+    leaf last-error {
+      type identityref {
+        base bn:bgp-notification;
+      }
+      description
+        "The last NOTIFICATION error for the peer on this
+         connection.  If no identity is registered for the
+         Error code / Error subcode, the last-error-code and
+         last-error-subcode will have the information received
+         in the NOTIFICATION PDU.";
+      reference
+        "RFC 4271, Section 4.5.";
+    }
+    leaf last-error-code {
+      type uint8;
+      description
+        "The last NOTIFICATION Error code for the peer on
+         this connection.";
+      reference
+        "RFC 4271, Section 4.5.";
+    }
+    leaf last-error-subcode {
+      type uint8;
+      description
+        "The last NOTIFICATION Error subcode for the peer on
+         this connection.";
+      reference
+        "RFC 4271, Section 4.5.";
+    }
+  }
+  grouping bgp-errors-common-data {
+    description
+      "BGP NOTIFICATION data state that is common in the sent and
+       received direction.";
+
+    leaf last-error-data {
+      type binary {
+        length "0..65535";
+      }
+      description
+        "Content of the BGP NOTIFICATION PDU's Data field.  This data
+         is NOTIFICATION Error code / Error subcode specific.";
+      reference
+        "RFC 4271, Section 4.5.";
+    }
   }
 
   /*
@@ -601,20 +666,26 @@ module ietf-bgp {
             description
               "Negotiated BGP capabilities.";
           }
-          leaf last-error {
-            type binary {
-              length "2";
-            }
+          container errors {
             config false;
             description
-              "The last error code and subcode seen by this
-               peer on this connection.  If no error has
-               occurred, this field is zero.  Otherwise, the
-               first byte of this two byte OCTET STRING
-               contains the error code, and the second byte
-               contains the subcode.";
-            reference
-              "RFC 4271, Section 4.5.";
+              "Information about BGP NOTIFICATION messages, sent and
+               received for this neighbor.";
+
+            container received {
+              description
+                "BGP NOTIFICATION message state received from this
+                 neighbor.";
+              uses bgp-errors-common;
+              uses bgp-errors-common-data;
+            }
+            container sent {
+              description
+                "BGP NOTIFICATION message state sent to this
+                 neighbor.";
+              uses bgp-errors-common;
+              uses bgp-errors-common-data;
+            }
           }
           leaf treat-as-withdraw {
             type boolean;
@@ -819,29 +890,6 @@ module ietf-bgp {
               "IP address of the neighbor that went into established
                state.";
           }
-          leaf last-error {
-            type leafref {
-              path "../../neighbor/last-error";
-            }
-            description
-              "The last error code and subcode seen by this
-               peer on this connection.  If no error has
-               occurred, this field is zero.  Otherwise, the
-               first octet of this two byte OCTET STRING
-               contains the error code, and the second octet
-               contains the subcode.";
-            reference
-              "RFC 4271, Section 4.5.";
-          }
-          leaf session-state {
-            type leafref {
-              path "../../neighbor/session-state";
-            }
-            description
-              "The BGP peer connection state.";
-            reference
-              "RFC 4271, Section 8.2.2.";
-          }
           description
             "The established event is generated
              when the BGP FSM enters the established state.";
@@ -856,29 +904,21 @@ module ietf-bgp {
               "IP address of the neighbor that changed its state from
                established state.";
           }
-          leaf last-error {
-            type leafref {
-              path "../../neighbor/last-error";
-            }
+          container notification-received {
             description
-              "The last error code and subcode seen by this
-               peer on this connection.  If no error has
-               occurred, this field is zero.  Otherwise, the
-               first byte of this two byte OCTET STRING
-               contains the error code, and the second byte
-               contains the subcode.";
-            reference
-              "RFC 4271, Section 4.5.";
+              "If the backwards transition was caused by receiving a
+               BGP NOTIFICATION message, this is the information
+               received in the NOTIFICATION PDU.";
+
+            uses bgp-errors-common;
           }
-          /* This lingers from RFC 4273 and might not be helpful? */
-          leaf session-state {
-            type leafref {
-              path "../../neighbor/session-state";
-            }
+          container notification-sent {
             description
-              "The BGP peer connection state.";
-            reference
-              "RFC 4271, Section 8.2.2.";
+              "If the backwards transition was caused by sending a
+               BGP NOTIFICATION message, this is the information
+               sent in the NOTIFICATION PDU.";
+
+            uses bgp-errors-common;
           }
           description
             "The backward-transition event is

--- a/src/yang/ietf-bgp.yang
+++ b/src/yang/ietf-bgp.yang
@@ -25,7 +25,7 @@ module ietf-bgp {
   }
   import iana-bgp-types {
     prefix bt;
-    reference/
+    reference
       "RFC XXXX: YANG Model for Border Gateway Protocol (BGP-4).";
   }
   import ietf-inet-types {


### PR DESCRIPTION
The old style RFC 4273 MIB stuff wasn't great, even for MIBs. Using inspiration from the OpenConfig identities, created a new sub-module for the hierarchy of BGP notification codes and sub-codes. Unlike the OC version, it's all anchored at a common root.  Most of the size of this module is providing the normative references for what the identity actually means.

Similarly, the model needs to carry the error-code and subcode for situations where the identity doesn't provide sufficient information.

The notification data and time are also added to this state.

The YANG notifications for the established and backward-transition state are similarly cleaned up and removed things that came directly from RFC 4273 that weren't particularly helpful.  As part of that work, the backwards-transition notification is now capable of putting directional data in it.

Closes #249
Closes #250
Partially addresses Issue #148 