### PR TITLE
Issue #296 - Add "disable-peer-as-filter" leaf to the as-options.

### DIFF
--- a/src/yang/ietf-bgp-common-structure.yang
+++ b/src/yang/ietf-bgp-common-structure.yang
@@ -150,6 +150,15 @@ submodule ietf-bgp-common-structure {
           "Replace occurrences of the peer's AS in the AS_PATH with
            the local autonomous system number";
       }
+      leaf disable-peer-as-filter {
+        type boolean;
+        default "false";
+        description
+          "When set to true, the system advertises routes to a peer
+           even if the peer's AS was in the AS path.  The default
+           behavior (false) suppresses advertisements to peers if
+           their AS number is in the AS path of the route.";
+      }
     }
   }
 


### PR DESCRIPTION
A useful feature in OC, added for parity.

Closes #296