### PR TITLE
Issue #298 - Make treat-as-withdraw group and neighbor common.

### DIFF
--- a/src/yang/ietf-bgp-common-structure.yang
+++ b/src/yang/ietf-bgp-common-structure.yang
@@ -62,10 +62,26 @@ submodule ietf-bgp-common-structure {
       "RFC XXXX: YANG Model for Border Gateway Protocol (BGP-4).";
   }
 
-  grouping structure-neighbor-group-logging-options {
+  grouping structure-neighbor-group-error-options {
     description
       "Structural grouping used to include error handling
        configuration and state for both BGP neighbors and groups";
+    leaf treat-as-withdraw {
+      type boolean;
+      default "false";
+      description
+        "Specify whether erroneous UPDATE messages for which the NLRI
+         can be extracted are treated as though the NLRI is withdrawn
+         - avoiding session reset";
+      reference
+        "RFC 7606: Revised Error Handling for BGP UPDATE Messages.";
+    }
+  }
+
+  grouping structure-neighbor-group-logging-options {
+    description
+      "Structural grouping used to include logging configuration and
+       state for both BGP neighbors and groups";
     container logging-options {
       description
         "Logging options for events related to the BGP neighbor or

--- a/src/yang/ietf-bgp-common-structure.yang
+++ b/src/yang/ietf-bgp-common-structure.yang
@@ -62,22 +62,6 @@ submodule ietf-bgp-common-structure {
       "RFC XXXX: YANG Model for Border Gateway Protocol (BGP-4).";
   }
 
-  grouping structure-neighbor-group-error-options {
-    description
-      "Structural grouping used to include error handling
-       configuration and state for both BGP neighbors and groups";
-    leaf treat-as-withdraw {
-      type boolean;
-      default "false";
-      description
-        "Specify whether erroneous UPDATE messages for which the NLRI
-         can be extracted are treated as though the NLRI is withdrawn
-         - avoiding session reset";
-      reference
-        "RFC 7606: Revised Error Handling for BGP UPDATE Messages.";
-    }
-  }
-
   grouping structure-neighbor-group-logging-options {
     description
       "Structural grouping used to include logging configuration and

--- a/src/yang/ietf-bgp.yang
+++ b/src/yang/ietf-bgp.yang
@@ -220,7 +220,17 @@ module ietf-bgp {
       }
     }
 
-    uses structure-neighbor-group-error-options;
+    leaf treat-as-withdraw {
+      type boolean;
+      default "false";
+      description
+        "Specify whether erroneous UPDATE messages for which the NLRI
+         can be extracted are treated as though the NLRI is withdrawn
+         - avoiding session reset";
+      reference
+        "RFC 7606: Revised Error Handling for BGP UPDATE Messages.";
+    }
+
     uses structure-neighbor-group-logging-options;
     uses structure-neighbor-group-route-reflector;
     uses structure-neighbor-group-as-path-options;

--- a/src/yang/ietf-bgp.yang
+++ b/src/yang/ietf-bgp.yang
@@ -219,6 +219,8 @@ module ietf-bgp {
            graceful restart with the peer";
       }
     }
+
+    uses structure-neighbor-group-error-options;
     uses structure-neighbor-group-logging-options;
     uses structure-neighbor-group-route-reflector;
     uses structure-neighbor-group-as-path-options;
@@ -538,17 +540,6 @@ module ietf-bgp {
                contains the subcode.";
             reference
               "RFC 4271, Section 4.5.";
-          }
-          leaf treat-as-withdraw {
-            type boolean;
-            default "false";
-            description
-              "Specify whether erroneous UPDATE messages for which
-               the NLRI can be extracted are treated as though the
-               NLRI is withdrawn - avoiding session reset";
-            reference
-              "RFC 7606: Revised Error Handling for BGP UPDATE
-               Messages.";
           }
 
           container statistics {


### PR DESCRIPTION
The treat-as-withdraw configuration was only in bgp/neighbors and needs also to be in bgp/peer-groups

Closes #298