### PR TITLE
Issue #291 Adjust counter types

### DIFF
--- a/src/yang/ietf-bgp-neighbor.yang
+++ b/src/yang/ietf-bgp-neighbor.yang
@@ -121,17 +121,17 @@ submodule ietf-bgp-neighbor {
         description
           "Prefix counters for the AFI/SAFI in this BGP session";
         leaf received {
-          type yang:counter32;
+          type yang:zero-based-counter32;
           description
             "The number of prefixes received from the neighbor";
         }
         leaf sent {
-          type yang:counter32;
+          type yang:zero-based-counter32;
           description
             "The number of prefixes advertised to the neighbor";
         }
         leaf installed {
-          type yang:counter32;
+          type yang:gauge32;
           description
             "The number of advertised prefixes installed in the
              Loc-RIB";

--- a/src/yang/ietf-bgp.yang
+++ b/src/yang/ietf-bgp.yang
@@ -634,7 +634,7 @@ module ietf-bgp {
               "Statistics per neighbor.";
 
             leaf established-transitions {
-              type yang:zero-based-counter64;
+              type yang:zero-based-counter32;
               description
                 "Number of transitions to the Established state for
                  the neighbor session. This value is analogous to the
@@ -651,7 +651,7 @@ module ietf-bgp {
                 "Counters for BGP messages sent and received from the
                  neighbor";
               leaf total-received {
-                type yang:zero-based-counter64;
+                type yang:zero-based-counter32;
                 description
                   "Total number of BGP messages received from this
                    neighbor";
@@ -660,7 +660,7 @@ module ietf-bgp {
                    BGP-4, bgpPeerInTotalMessages.";
               }
               leaf total-sent {
-                type yang:zero-based-counter64;
+                type yang:zero-based-counter32;
                 description
                   "Total number of BGP messages sent do this
                    neighbor";
@@ -669,7 +669,7 @@ module ietf-bgp {
                    BGP-4, bgpPeerOutTotalMessages.";
               }
               leaf updates-received {
-                type yang:zero-based-counter64;
+                type yang:zero-based-counter32;
                 description
                   "Number of BGP UPDATE messages received from this
                    neighbor.";
@@ -678,7 +678,7 @@ module ietf-bgp {
                    BGP-4, bgpPeerInUpdates.";
               }
               leaf updates-sent {
-                type yang:zero-based-counter64;
+                type yang:zero-based-counter32;
                 description
                   "Number of BGP UPDATE messages sent to this
                    neighbor";
@@ -687,7 +687,7 @@ module ietf-bgp {
                    BGP-4, bgpPeerOutUpdates.";
               }
               leaf erroneous-updates-withdrawn {
-                type yang:zero-based-counter64;
+                type yang:zero-based-counter32;
                 config false;
                 description
                   "The number of BGP UPDATE messages for which the
@@ -698,7 +698,7 @@ module ietf-bgp {
                    Messages, Section 2.";
               }
               leaf erroneous-updates-attribute-discarded {
-                type yang:zero-based-counter64;
+                type yang:zero-based-counter32;
                 config false;
                 description
                   "The number of BGP UPDATE messages for which the
@@ -723,7 +723,7 @@ module ietf-bgp {
                    Established state.";
               }
               leaf notifications-received {
-                type yang:zero-based-counter64;
+                type yang:zero-based-counter32;
                 description
                   "Number of BGP NOTIFICATION messages indicating an
                    error condition has occurred exchanged received
@@ -733,7 +733,7 @@ module ietf-bgp {
                    Section 4.5.";
               }
               leaf notifications-sent {
-                type yang:zero-based-counter64;
+                type yang:zero-based-counter32;
                 description
                   "Number of BGP NOTIFICATION messages indicating an
                    error condition has occurred exchanged sent to
@@ -743,7 +743,7 @@ module ietf-bgp {
                    Section 4.5.";
               }
               leaf route-refreshes-received {
-                type yang:zero-based-counter64;
+                type yang:zero-based-counter32;
                 description
                   "Number of BGP ROUTE-REFRESH messages received from
                    this peer.";
@@ -751,7 +751,7 @@ module ietf-bgp {
                   "RFC 2918: Route Refresh Capability for BGP-4.";
               }
               leaf route-refreshes-sent {
-                type yang:zero-based-counter64;
+                type yang:zero-based-counter32;
                 description
                   "Number of BGP ROUTE-REFRESH messages sent to
                    this peer.";
@@ -764,13 +764,13 @@ module ietf-bgp {
                 "Counters related to queued messages associated with
                  the BGP neighbor";
               leaf input {
-                type yang:counter32;
+                type yang:gauge32;
                 description
                   "The number of messages received from the peer
                    currently queued";
               }
               leaf output {
-                type yang:counter32;
+                type yang:gauge32;
                 description
                   "The number of messages queued to be sent to the
                    peer";


### PR DESCRIPTION
Audit counter types and make them appropriate counter/gauge types. In general, make all counters 32 bit counters.  BGP even over long lifespan and high scale shouldn't be having things that exceed a 32 bit counter.

Closes #291 