### PR TITLE
Issue #281 Eliminate grouping neighbor-group-config

### DIFF
--- a/src/yang/ietf-bgp-common-structure.yang
+++ b/src/yang/ietf-bgp-common-structure.yang
@@ -14,8 +14,6 @@ submodule ietf-bgp-common-structure {
     reference
       "RFC XXXX: YANG Model for Border Gateway Protocol (BGP-4).";
   }
-  include ietf-bgp-common-multiprotocol;
-  include ietf-bgp-common;
 
   // meta
 

--- a/src/yang/ietf-bgp-common.yang
+++ b/src/yang/ietf-bgp-common.yang
@@ -94,7 +94,7 @@ submodule ietf-bgp-common {
       "RFC XXXX: YANG Model for Border Gateway Protocol (BGP-4).";
   }
 
-  grouping neighbor-group-timers-config {
+  grouping neighbor-group-timers {
     description
       "Config parameters related to timers associated with the BGP
        peer";
@@ -352,7 +352,7 @@ submodule ietf-bgp-common {
     container timers {
       description
         "Timers related to a BGP neighbor";
-      uses neighbor-group-timers-config;
+      uses neighbor-group-timers;
     }
 
     container transport {

--- a/src/yang/ietf-bgp-common.yang
+++ b/src/yang/ietf-bgp-common.yang
@@ -24,6 +24,11 @@ submodule ietf-bgp-common {
     reference
       "RFC 6991: Common YANG Data Types.";
   }
+  import ietf-routing-policy {
+    prefix rt-pol;
+    reference
+      "RFC 9067: A YANG Data Model for Routing Policy.";
+  }
   import ietf-yang-types {
     prefix yang;
     reference
@@ -40,6 +45,9 @@ submodule ietf-bgp-common {
     reference
       "I-D.ietf-tcpm-yang-tcp: Transmission Control Protocol (TCP)
        YANG Model.";
+  }
+  include ietf-bgp-common-structure {
+    revision-date YYYY-MM-DD;
   }
 
   organization
@@ -196,6 +204,36 @@ submodule ietf-bgp-common {
     }
   }
 
+  grouping bgp-neighbor-use-multiple-paths {
+    description
+      "Multi-path configuration and state applicable to a BGP
+       neighbor";
+    container use-multiple-paths {
+      description
+        "Parameters related to the use of multiple-paths for the same
+         NLRI when they are received only from this neighbor";
+      leaf enabled {
+        type boolean;
+        default "false";
+        description
+          "Whether the use of multiple paths for the same NLRI is
+           enabled for the neighbor.";
+      }
+      container ebgp {
+        description
+          "Multi-path configuration for eBGP";
+        leaf allow-multiple-as {
+          type boolean;
+          default "false";
+          description
+            "Allow multi-path to use paths from different neighboring
+             ASes. The default is to only consider multiple paths
+             from the same neighboring AS.";
+        }
+      }
+    }
+  }
+
   grouping neighbor-group-config {
     description
       "Neighbor level configuration items.";
@@ -310,6 +348,36 @@ submodule ietf-bgp-common {
         "An optional textual description (intended primarily for use
          with a peer or group";
     }
+
+    container timers {
+      description
+        "Timers related to a BGP neighbor";
+      uses neighbor-group-timers-config;
+    }
+
+    container transport {
+      description
+        "Transport session parameters for the BGP neighbor";
+      uses neighbor-group-transport-config;
+    }
+
+    leaf treat-as-withdraw {
+      type boolean;
+      default "false";
+      description
+        "Specify whether erroneous UPDATE messages for which the NLRI
+         can be extracted are treated as though the NLRI is withdrawn
+         - avoiding session reset";
+      reference
+        "RFC 7606: Revised Error Handling for BGP UPDATE Messages.";
+    }
+
+    uses structure-neighbor-group-logging-options;
+    uses structure-neighbor-group-route-reflector;
+    uses structure-neighbor-group-as-path-options;
+    uses structure-add-paths;
+    uses bgp-neighbor-use-multiple-paths;
+    uses rt-pol:apply-policy-group;
   }
 
   grouping neighbor-group-transport-config {

--- a/src/yang/ietf-bgp-neighbor.yang
+++ b/src/yang/ietf-bgp-neighbor.yang
@@ -66,37 +66,6 @@ submodule ietf-bgp-neighbor {
       "RFC XXXX: YANG Model for Border Gateway Protocol (BGP-4).";
   }
 
-  grouping bgp-neighbor-use-multiple-paths {
-    description
-      "Multi-path configuration and state applicable to a BGP
-       neighbor";
-    container use-multiple-paths {
-      description
-        "Parameters related to the use of multiple-paths for the same
-         NLRI when they are received only from this neighbor";
-      leaf enabled {
-        type boolean;
-        default "false";
-        description
-          "Whether the use of multiple paths for the same NLRI is
-           enabled for the neighbor.";
-      }
-      container ebgp {
-        description
-          "Multi-path configuration for eBGP";
-        leaf allow-multiple-as {
-          type boolean;
-          default "false";
-          description
-            "Allow multi-path to use paths from different neighboring
-             ASes. The default is to only consider multiple paths
-             from the same neighboring AS.";
-        }
-      }
-    }
-  }
-
-
   grouping bgp-neighbor-afi-safi-list {
     description
       "List of address-families associated with the BGP neighbor";

--- a/src/yang/ietf-bgp.yang
+++ b/src/yang/ietf-bgp.yang
@@ -146,35 +146,6 @@ module ietf-bgp {
     description
       "Neighbor and Peer Group configuration that is common.";
 
-    container timers {
-      description
-        "Timers related to a BGP neighbor";
-      uses neighbor-group-timers-config;
-    }
-
-    container transport {
-      description
-        "Transport session parameters for the BGP neighbor";
-      uses neighbor-group-transport-config;
-    }
-
-    leaf treat-as-withdraw {
-      type boolean;
-      default "false";
-      description
-        "Specify whether erroneous UPDATE messages for which the NLRI
-         can be extracted are treated as though the NLRI is withdrawn
-         - avoiding session reset";
-      reference
-        "RFC 7606: Revised Error Handling for BGP UPDATE Messages.";
-    }
-
-    uses structure-neighbor-group-logging-options;
-    uses structure-neighbor-group-route-reflector;
-    uses structure-neighbor-group-as-path-options;
-    uses structure-add-paths;
-    uses bgp-neighbor-use-multiple-paths;
-    uses rt-pol:apply-policy-group;
   }
 
   grouping bgp-errors-common {
@@ -472,6 +443,7 @@ module ietf-bgp {
           }
 
           uses neighbor-group-config;
+
           container graceful-restart {
             if-feature "bt:graceful-restart";
             description
@@ -538,7 +510,6 @@ module ietf-bgp {
                  graceful restart with the peer";
             }
           }
-          uses neighbor-and-peer-group-common;
 
           container afi-safis {
             description
@@ -948,8 +919,6 @@ module ietf-bgp {
               "RFC 4724: Graceful Restart Mechanism for BGP.";
             uses graceful-restart-config;
           }
-
-          uses neighbor-and-peer-group-common;
 
           container afi-safis {
             description


### PR DESCRIPTION
grouping neighbor-group-config is used in exactly the same places that grouping neighbor-and-peer-group-common are used, so they're really the same thing.

Eliminate neighbor-group config.  This required restructuring some of the dependencies of the submodules.

Note that this causes the graceful-restart config and state to bubble down in the hierarchy where used in the neighbors and peer-groups.

Closes #281