### PR TITLE
Issue #148 RFC 8538 encapsulated notification support

### DIFF
--- a/src/yang/ietf-bgp.yang
+++ b/src/yang/ietf-bgp.yang
@@ -244,6 +244,55 @@ module ietf-bgp {
     }
   }
 
+  grouping bgp-encapsulated-errors-common {
+    description
+      "BGP NOTIFICATION state that is common in the sent and received
+       direction that has been encapsulated in a CEASE/HARD RESET
+       NOTIFICATION.
+
+       Note that these leaves are only present when carrying the RFC
+       8538 encapsulated NOTIFICATION state. In this case,
+       the last-error-data leaf will carry the encapsulated Data.";
+      
+    leaf last-encapsulated-error {
+      type identityref {
+        base bn:bgp-notification;
+      }
+      description
+        "The last RFC 8538 encapsulated NOTIFICATION error for the
+         peer on this connection.  If no identity is registered for
+         the Error code / Error subcode, this leaf contains the most
+         applicable identity for the BGP NOTIFICATION base code.
+
+         The last-encapsulated-error-code and
+         last-encapsulated-error-subcode will always have the
+         encapsulated information received in the CEASE/HARD RESET
+         NOTIFICATION PDU's encapsulated ErrCode and Subcode
+         fields.";
+      reference
+        "RFC 8538: Notification Message Support for BGP Graceful
+         Restart, Section 3.1.";
+    }
+    leaf last-encapsulated-error-code {
+      type uint8;
+      description
+        "The last RFC 8538 encapsulated NOTIFICATION Error code for
+         the peer on this connection.";
+      reference
+        "RFC 8538: Notification Message Support for BGP Graceful
+         Restart, Section 3.1.";
+    }
+    leaf last-encapsulated-error-subcode {
+      type uint8;
+      description
+        "The last RFC 8538 encapsulated NOTIFICATION Error subcode
+         for the peer on this connection.";
+      reference
+        "RFC 8538: Notification Message Support for BGP Graceful
+         Restart, Section 3.1.";
+    }
+  }
+
   /*
    * Containers
    */
@@ -621,6 +670,7 @@ module ietf-bgp {
                 "BGP NOTIFICATION message state received from this
                  neighbor.";
               uses bgp-errors-common;
+              uses bgp-encapsulated-errors-common;
               uses bgp-errors-common-data;
             }
             container sent {
@@ -628,6 +678,7 @@ module ietf-bgp {
                 "BGP NOTIFICATION message state sent to this
                  neighbor.";
               uses bgp-errors-common;
+              uses bgp-encapsulated-errors-common;
               uses bgp-errors-common-data;
             }
           }
@@ -837,6 +888,7 @@ module ietf-bgp {
                received in the NOTIFICATION PDU.";
 
             uses bgp-errors-common;
+            uses bgp-encapsulated-errors-common;
           }
           container notification-sent {
             description
@@ -845,6 +897,7 @@ module ietf-bgp {
                sent in the NOTIFICATION PDU.";
 
             uses bgp-errors-common;
+            uses bgp-encapsulated-errors-common;
           }
           description
             "The backward-transition event is


### PR DESCRIPTION
Since a bit identity had to be registered for the Graceful restart type and it was better to simply add the RFC 8538 bit as part of our initial version, finish the work to display encapsulated notifications from RFC 8538 when processing a CEASE/HARD RESET.

Since these leaves are optional, there's no need to protect it with an if-feature.

Closes #148