### PR TITLE
Issue #53 Document a community regular expression format

### DIFF
--- a/src/yang/iana-bgp-types.yang
+++ b/src/yang/iana-bgp-types.yang
@@ -512,7 +512,21 @@ module iana-bgp-types {
     type string;
     description
       "Type definition for communities specified as regular
-       expression patterns";
+       expression patterns.
+
+       A compliant implementation of this type MUST accept a POSIX.2
+       Extended Regular Expression excluding the following features:
+       - character class expressions (Section 9.3.5)
+       - collating symbols (Section 9.3.5)
+       - equivalence classes (Section 9.3.5)
+       - back-reference expressions (Section 9.3.6)
+
+       Implementations MAY accept additional forms of regular
+       expressions as long as the minimally compliant form documented
+       above is accepted.";
+    reference
+      "IEEE Std 1003.1-2017: The Open Group Base Specifications Issue
+       7, 2018 edition.";
   }
 
   typedef bgp-origin-attr-type {

--- a/src/yang/ietf-bgp.yang
+++ b/src/yang/ietf-bgp.yang
@@ -244,6 +244,55 @@ module ietf-bgp {
     }
   }
 
+  grouping bgp-encapsulated-errors-common {
+    description
+      "BGP NOTIFICATION state that is common in the sent and received
+       direction that has been encapsulated in a CEASE/HARD RESET
+       NOTIFICATION.
+
+       Note that these leaves are only present when carrying the RFC
+       8538 encapsulated NOTIFICATION state. In this case,
+       the last-error-data leaf will carry the encapsulated Data.";
+      
+    leaf last-encapsulated-error {
+      type identityref {
+        base bn:bgp-notification;
+      }
+      description
+        "The last RFC 8538 encapsulated NOTIFICATION error for the
+         peer on this connection.  If no identity is registered for
+         the Error code / Error subcode, this leaf contains the most
+         applicable identity for the BGP NOTIFICATION base code.
+
+         The last-encapsulated-error-code and
+         last-encapsulated-error-subcode will always have the
+         encapsulated information received in the CEASE/HARD RESET
+         NOTIFICATION PDU's encapsulated ErrCode and Subcode
+         fields.";
+      reference
+        "RFC 8538: Notification Message Support for BGP Graceful
+         Restart, Section 3.1.";
+    }
+    leaf last-encapsulated-error-code {
+      type uint8;
+      description
+        "The last RFC 8538 encapsulated NOTIFICATION Error code for
+         the peer on this connection.";
+      reference
+        "RFC 8538: Notification Message Support for BGP Graceful
+         Restart, Section 3.1.";
+    }
+    leaf last-encapsulated-error-subcode {
+      type uint8;
+      description
+        "The last RFC 8538 encapsulated NOTIFICATION Error subcode
+         for the peer on this connection.";
+      reference
+        "RFC 8538: Notification Message Support for BGP Graceful
+         Restart, Section 3.1.";
+    }
+  }
+
   /*
    * Containers
    */
@@ -621,6 +670,7 @@ module ietf-bgp {
                 "BGP NOTIFICATION message state received from this
                  neighbor.";
               uses bgp-errors-common;
+              uses bgp-encapsulated-errors-common;
               uses bgp-errors-common-data;
             }
             container sent {
@@ -628,6 +678,7 @@ module ietf-bgp {
                 "BGP NOTIFICATION message state sent to this
                  neighbor.";
               uses bgp-errors-common;
+              uses bgp-encapsulated-errors-common;
               uses bgp-errors-common-data;
             }
           }
@@ -837,6 +888,7 @@ module ietf-bgp {
                received in the NOTIFICATION PDU.";
 
             uses bgp-errors-common;
+            uses bgp-encapsulated-errors-common;
           }
           container notification-sent {
             description
@@ -845,6 +897,7 @@ module ietf-bgp {
                sent in the NOTIFICATION PDU.";
 
             uses bgp-errors-common;
+            uses bgp-encapsulated-errors-common;
           }
           description
             "The backward-transition event is


### PR DESCRIPTION
Based on high level survey of several implementations, make a recommendation
that we'll use a subset of POSIX.2 Extended Regular Expressions.  This may
still be too expressive for some implementations, but should be implementable
using POSIX regex().
    
I suspect this will get some contentious discussion in the IETF IDR Working Group.
    
