### PR TITLE
Issue #309 Dynamic peers feature

### DIFF
--- a/src/yang/ietf-bgp-common-structure.yang
+++ b/src/yang/ietf-bgp-common-structure.yang
@@ -14,6 +14,11 @@ submodule ietf-bgp-common-structure {
     reference
       "RFC XXXX: YANG Model for Border Gateway Protocol (BGP-4).";
   }
+  import ietf-inet-types {
+    prefix inet;
+    reference
+      "RFC 6991: Common YANG Data Types.";
+  }
   include ietf-bgp-common-multiprotocol;
   include ietf-bgp-common;
 
@@ -209,6 +214,32 @@ submodule ietf-bgp-common-structure {
         description
           "A reference to a routing policy which can be used to
            restrict the prefixes for which add-paths is enabled";
+      }
+    }
+  }
+
+  grouping structure-dynamic-peers {
+    description
+      "Structural grouping to contain dyamic BGP peers. Dynamic
+       peers are configured from a list of IP prefixes matching the
+       IP source address of the dynamic peer.";
+
+    container dynamic-peers {
+      description
+        "Configuration and operational state for dynamically
+         configured peers.";
+
+      list dynamic-peer-list {
+        key "prefix";
+        description
+          "List of peers by IP prefix for this configuration scope
+           that are dynamically configured.";
+
+        leaf prefix {
+          type inet:ip-prefix;
+          description
+            "Prefix for dynamic peer at this configuration scope.";
+        }
       }
     }
   }

--- a/src/yang/ietf-bgp.yang
+++ b/src/yang/ietf-bgp.yang
@@ -174,6 +174,7 @@ module ietf-bgp {
     uses structure-neighbor-group-as-path-options;
     uses structure-add-paths;
     uses bgp-neighbor-use-multiple-paths;
+    uses structure-dynamic-peers;
     uses rt-pol:apply-policy-group;
   }
 
@@ -444,6 +445,14 @@ module ietf-bgp {
             reference
               "RFC 4271: A Border Gateway Protocol 4 (BGP-4),
                          Section 4.2, 'BGP Identifier'.";
+          }
+
+          leaf dynamically-configured {
+            type empty;
+            config false;
+            description
+              "When present, this peer has been created
+              dynamically.";
           }
 
           leaf enabled {


### PR DESCRIPTION
Many implementations of BGP support dynamic peers.  Most tend to configure it from peer-group scope.  This commit adds dynamic peers as a grouping that is used at the per-group scope.  Its structure is a container with a single list where the prefixes of the peers are configured.

While this modeling is mostly empty space, it enables two flavors of extensibility:
1. The list keyed by prefix can have additional per-prefix configuration.  This accommodates features in some vendors to further restrict peers on a per-prefix basis.
2. The empty container allows per-container augmentation as well.

If an implementation prefers to model this similar to OpenConfig with a top-level bgp dynamic peers container, this grouping can be augmented in at the global level to provide naming consistency.

Closes #309