### PR TITLE
Issue #324 Need a selector for extended community matches

### DIFF
--- a/src/yang/ietf-bgp-policy.yang
+++ b/src/yang/ietf-bgp-policy.yang
@@ -479,6 +479,26 @@ module ietf-bgp-policy {
           description
             "References a defined extended community set.";
         }
+        leaf ext-community-match-kind {
+          type enumeration {
+            enum ext-community {
+              description
+                "Perform the match against the ext-community RIB
+                 attribute.";
+            }
+            enum ext-community-raw {
+              description
+                "Perform the match against the ext-community-raw RIB
+                 attribute.";
+            }
+          }
+          default ext-community;
+          description
+            "Extended communities may be matched by the ext-community
+             RIB attribute, or the ext-community-raw RIB attribute.
+             This leaf selects which leaf to perform the match
+             operation against.";
+        }
         uses rt-pol:match-set-options-group;
       }
 


### PR DESCRIPTION
Extended communities are presented in the RIB model as a human-friendly format
- which may be absent - and a guaranteed to be present raw format.  There is a need for a selector for picking what kind of extended community leaf matches happen against.

Closes #324