### PR TITLE
Issue #333 Fix broken dynamic-peers usage

### DIFF
--- a/src/yang/ietf-bgp.yang
+++ b/src/yang/ietf-bgp.yang
@@ -975,6 +975,7 @@ module ietf-bgp {
           }
 
           uses neighbor-group-config;
+          uses structure-dynamic-peers;
 
           container graceful-restart {
             if-feature "bt:graceful-restart";


### PR DESCRIPTION
Issue #281's merge broke this feature.  Restored at peer-group scope.

Closes #333