### PR TITLE
Issue 361: Provide a send-community identity of none

### DIFF
--- a/src/yang/iana-bgp-community-types.yang
+++ b/src/yang/iana-bgp-community-types.yang
@@ -142,6 +142,13 @@ module iana-bgp-community-types {
       "Base identity to identify send-community feature.";
   }
 
+  identity none {
+    base send-community-feature;
+    description
+      "Send no communities.  When used, no other community types
+       should be present.";
+  }
+
   identity standard {
     base send-community-feature;
     description


### PR DESCRIPTION
Fixes: #361 