### PR TITLE
Issue 422: Move to current style xi includes for references to silence warning

### DIFF
--- a/draft/draft-ietf-idr-bgp-model.xml
+++ b/draft/draft-ietf-idr-bgp-model.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="US-ASCII"?>
 <rfc
+    xmlns:xi="http://www.w3.org/2001/XInclude"
     category="std"
     docName="draft-ietf-idr-bgp-model-latest"
     ipr="trust200902"
@@ -958,113 +959,113 @@ INSERT_TEXT_FROM_FILE(../bin/submodules/ietf-bgp-rib-tables@YYYY-MM-DD.yang)
 
   <back>
     <references title="Normative references">
-      <?rfc include='reference.RFC.1997.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.1997.xml"/>
 
-      <?rfc include='reference.RFC.2119.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.2119.xml"/>
 
-      <?rfc include='reference.RFC.2439.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.2439.xml"/>
 
-      <?rfc include='reference.RFC.2918.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.2918.xml"/>
 
-      <?rfc include='reference.RFC.3688.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.3688.xml"/>
 
-      <?rfc include='reference.RFC.4271.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.4271.xml"/>
 
-      <?rfc include='reference.RFC.4360.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.4360.xml"/>
 
-      <?rfc include='reference.RFC.4364.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.4364.xml"/>
 
-      <?rfc include='reference.RFC.4456.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.4456.xml"/>
 
-      <?rfc include='reference.RFC.4659.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.4659.xml"/>
 
-      <?rfc include='reference.RFC.4724.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.4724.xml"/>
 
-      <?rfc include='reference.RFC.4760.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.4760.xml"/>
 
-      <?rfc include='reference.RFC.4761.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.4761.xml"/>
 
-      <?rfc include='reference.RFC.5065.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.5065.xml"/>
 
-      <?rfc include='reference.RFC.5701.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.5701.xml"/>
 
-      <?rfc include='reference.RFC.5880.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.5880.xml"/>
 
-      <?rfc include='reference.RFC.5881.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.5881.xml"/>
 
-      <?rfc include='reference.RFC.5883.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.5883.xml"/>
 
-      <?rfc include='reference.RFC.6020.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.6020.xml"/>
 
-      <?rfc include='reference.RFC.6241.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.6241.xml"/>
 
-      <?rfc include='reference.RFC.6242.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.6242.xml"/>
 
-      <?rfc include='reference.RFC.6514.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.6514.xml"/>
 
-      <?rfc include='reference.RFC.6793.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.6793.xml"/>
 
-      <?rfc include='reference.RFC.6811.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.6811.xml"/>
 
-      <?rfc include='reference.RFC.6991.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.6991.xml"/>
 
-      <?rfc include='reference.RFC.7607.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.7607.xml"/>
 
-      <?rfc include='reference.RFC.7911.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.7911.xml"/>
 
-      <?rfc include='reference.RFC.7950.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.7950.xml"/>
 
-      <?rfc include='reference.RFC.8040.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.8040.xml"/>
 
-      <?rfc include='reference.RFC.8092.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.8092.xml"/>
 
-      <?rfc include='reference.RFC.8174.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.8174.xml"/>
 
-      <?rfc include='reference.RFC.8177.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.8177.xml"/>
 
-      <?rfc include='reference.RFC.8277.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.8277.xml"/>
 
-      <?rfc include='reference.RFC.8341.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.8341.xml"/>
 
-      <?rfc include='reference.RFC.8349.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.8349.xml"/>
 
-      <?rfc include='reference.RFC.8446.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.8446.xml"/>
 
-      <?rfc include='reference.RFC.8528.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.8528.xml"/>
 
-      <?rfc include='reference.RFC.8529.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.8529.xml"/>
 
-      <?rfc include='reference.RFC.9067.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.9067.xml"/>
 
-      <?rfc include='reference.RFC.9293.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.9293.xml"/>
 
-      <?rfc include='reference.RFC.9314.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.9314.xml"/>
 
-      <?rfc include='reference.RFC.9648.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.9648.xml"/>
     </references>
 
     <references title="Informative references">
-      <?rfc include='reference.RFC.2385.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.2385.xml"/>
 
-      <?rfc include='reference.RFC.2622.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.2622.xml"/>
 
-      <?rfc include='reference.RFC.3765.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.3765.xml"/>
 
-      <?rfc include='reference.RFC.4451.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.4451.xml"/>
 
-      <?rfc include='reference.RFC.5082.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.5082.xml"/>
 
-      <?rfc include='reference.RFC.5398.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.5398.xml"/>
 
-      <?rfc include='reference.RFC.5925.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.5925.xml"/>
 
-      <?rfc include='reference.RFC.6151.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.6151.xml"/>
 
-      <?rfc include='reference.RFC.7454.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.7454.xml"/>
 
-      <?rfc include='reference.RFC.8342.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.8342.xml"/>
 
-      <?rfc include='reference.RFC.9774.xml'?>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.9774.xml"/>
     </references>
 
     <section title="Examples">


### PR DESCRIPTION
Fixes: #422 