### PR TITLE
Issue 397: Remove negotiated-hold-time

### DIFF
--- a/src/yang/ietf-bgp-common.yang
+++ b/src/yang/ietf-bgp-common.yang
@@ -143,15 +143,6 @@ submodule ietf-bgp-common {
         "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 4.2,
          RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 10.";
     }
-    leaf negotiated-hold-time {
-      type uint16;
-      config false;
-      description
-        "The negotiated hold-time for the BGP session";
-      reference
-        "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 4.2,
-         RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 10.";
-    }
     leaf keepalive {
       type uint16 {
         range "0..21845";


### PR DESCRIPTION
As noted in the issue, since IETF access protocols can distinguish between operational state vs. configuration state, we don't need the op-only "negotiated-hold-time".