### PR TITLE
Issue 420: Add treat-as-withdraw to global scope

### DIFF
--- a/src/yang/ietf-bgp-common.yang
+++ b/src/yang/ietf-bgp-common.yang
@@ -248,6 +248,16 @@ submodule ietf-bgp-common {
         "RFC 7705: Autonomous System Migration Mechanisms and Their
          Effects on the BGP AS_PATH Attribute.";
     }
+    leaf treat-as-withdraw {
+      type boolean;
+      default "false";
+      description
+        "Specify whether erroneous UPDATE messages for which the NLRI
+         can be extracted are treated as though the NLRI is withdrawn
+         - avoiding session reset";
+      reference
+        "RFC 7606: Revised Error Handling for BGP UPDATE Messages.";
+    }
     leaf enforce-first-as {
        type boolean;
        description
@@ -377,17 +387,6 @@ submodule ietf-bgp-common {
       description
         "Transport session parameters for the BGP neighbor";
       uses neighbor-group-transport-config;
-    }
-
-    leaf treat-as-withdraw {
-      type boolean;
-      default "false";
-      description
-        "Specify whether erroneous UPDATE messages for which the NLRI
-         can be extracted are treated as though the NLRI is withdrawn
-         - avoiding session reset";
-      reference
-        "RFC 7606: Revised Error Handling for BGP UPDATE Messages.";
     }
 
     container logging-options {

--- a/src/yang/ietf-bgp.yang
+++ b/src/yang/ietf-bgp.yang
@@ -162,6 +162,17 @@ module ietf-bgp {
             "Local autonomous system number of the router.  Uses
              the 32-bit as-number type from the model in RFC 6991.";
         }
+        leaf treat-as-withdraw {
+          type boolean;
+          default "false";
+          description
+            "Specify whether erroneous UPDATE messages for which the
+             NLRI can be extracted are treated as though the NLRI is
+             withdrawn - avoiding session reset";
+          reference
+            "RFC 7606: Revised Error Handling for BGP UPDATE
+             Messages.";
+        }
         leaf enforce-first-as {
            type boolean;
            description


### PR DESCRIPTION
Fixes: #420

Additionally, move the location of this to be next to enforce-first-as.