### PR TITLE
Issue 461: Add extended-community-count policy

### DIFF
--- a/src/yang/ietf-bgp-policy.yang
+++ b/src/yang/ietf-bgp-policy.yang
@@ -463,6 +463,21 @@ module ietf-bgp-policy {
         uses equality-operator;
       }
 
+      container extended-community-count {
+        description
+          "Value and comparison operations for conditions based on
+           the number of extended communities in the route update.";
+
+        leaf extended-community-count {
+          type uint32;
+          description
+            "Value for the number of communities in the route
+             update.";
+        }
+
+        uses equality-operator;
+      }
+
       container as-path-length {
         description
           "Value and comparison operations for conditions based on


### PR DESCRIPTION
Addresses OpenConfig parity. Fixes: #461

Note that the content of this container may be impacted by the resolution of issue #462.