### PR TITLE
Issue 462: Update policy to be more consistent in naming

### DIFF
--- a/src/yang/ietf-bgp-policy.yang
+++ b/src/yang/ietf-bgp-policy.yang
@@ -455,7 +455,7 @@ module ietf-bgp-policy {
           "Value and comparison operations for conditions based on
            the number of communities in the route update.";
 
-        leaf community-count {
+        leaf value {
           type uint32;
           description
             "Value for the number of communities in the route
@@ -470,7 +470,7 @@ module ietf-bgp-policy {
           "Value and comparison operations for conditions based on
            the number of extended communities in the route update.";
 
-        leaf extended-community-count {
+        leaf value {
           type uint32;
           description
             "Value for the number of communities in the route
@@ -490,7 +490,7 @@ module ietf-bgp-policy {
         reference
           "RFC 4271: A Border Gateway Protocol 4 (BGP-4).";
 
-        leaf as-path-length {
+        leaf value {
           type uint32;
           description
             "Value of the AS path length in the route update.";


### PR DESCRIPTION
Fixes: #462

When the pattern of policy is of the form
container foo {
leaf foo; // To be matched
uses compare-oper;
}

the second instance of foo is cognitive noise.

As we have elswhere, simply label the leaf "value".