### PR TITLE
Issue 400: Remove default for treat-as-withdraw

### DIFF
--- a/src/yang/ietf-bgp-common.yang
+++ b/src/yang/ietf-bgp-common.yang
@@ -251,11 +251,11 @@ submodule ietf-bgp-common {
     }
     leaf treat-as-withdraw {
       type boolean;
-      default "false";
       description
         "Specify whether erroneous UPDATE messages for which the NLRI
          can be extracted are treated as though the NLRI is withdrawn
-         - avoiding session reset";
+         - avoiding session reset.  The suggested implementation
+         default is true.";
       reference
         "RFC 7606: Revised Error Handling for BGP UPDATE Messages.";
     }

--- a/src/yang/ietf-bgp.yang
+++ b/src/yang/ietf-bgp.yang
@@ -164,11 +164,11 @@ module ietf-bgp {
         }
         leaf treat-as-withdraw {
           type boolean;
-          default "false";
           description
             "Specify whether erroneous UPDATE messages for which the
              NLRI can be extracted are treated as though the NLRI is
-             withdrawn - avoiding session reset";
+             withdrawn - avoiding session reset.  The suggested
+             implementation default is true.";
           reference
             "RFC 7606: Revised Error Handling for BGP UPDATE
              Messages.";


### PR DESCRIPTION
The treat-as-withdraw leaf had a default for false.  Defaults manifest in the model as nodes when you don't explicitly set them.  These days we want treat-as-default to be on by default, when supported.  However, we also have been moving to a pattern where we don't add defaults to the model to permit implementations to have their own internal defaults.

Fixes: #400