### PR TITLE
Issue #481 Clean up description for last-established

### DIFF
--- a/src/yang/ietf-bgp.yang
+++ b/src/yang/ietf-bgp.yang
@@ -534,13 +534,11 @@ module ietf-bgp {
             description
               "This timestamp indicates the time that the BGP session
                last transitioned in or out of the Established state.
-               The value is the timestamp in seconds relative to the
-               Unix Epoch (Jan 1, 1970 00:00:00 UTC).
 
                The BGP session uptime can be computed by clients as
                the difference between this value and the current time
-               in UTC (assuming the session is in the Established
-               state, per the session-state leaf).";
+               (assuming the session is in the Established state,
+               per the session-state leaf).";
             reference
               "RFC 4271: A Border Gateway Protocol 4 (BGP-4),
                Section 8.";


### PR DESCRIPTION
Remove references to unix epoch and UTC.
Closes #481