### PR TITLE
Address Maria's feedback on -20

### DIFF
--- a/draft/draft-ietf-idr-bgp-model.xml
+++ b/draft/draft-ietf-idr-bgp-model.xml
@@ -320,6 +320,12 @@ INSERT_TEXT_FROM_FILE(../bin/ietf-bgp@YYYY-MM-DD-sub-tree.txt)
         neighbor-specific configuration options which are relevant to the
         entire BGP instance.</t>
 
+        <t>In addition to explicit neighbor configuration, remote BGP neighbors
+        may establish sessions dynamically with the local BGP speaker.  This is
+        configured using the 'dynamic-peers' container which uses a prefix-list
+        to control IP subnets permitted to establish such dynamic peering
+        sessions.</t>
+
         <t>The model makes the simplifying assumption that most of the
         configuration items are available at all levels of the hierarchy. That
         is, very little configuration is specific to a particular level in the

--- a/src/yang/ietf-bgp-common.yang
+++ b/src/yang/ietf-bgp-common.yang
@@ -363,6 +363,8 @@ submodule ietf-bgp-common {
       description
         "Routes learned via BGP are subject to weighted route
          damping.";
+      reference
+        "RFC 2439: BGP Route Flap Damping.";
     }
     leaf-list send-community {
       if-feature "ibct:send-communities";

--- a/src/yang/ietf-bgp-common.yang
+++ b/src/yang/ietf-bgp-common.yang
@@ -373,7 +373,8 @@ submodule ietf-bgp-common {
       }
       description
         "When supported, this tells the router to propagate any
-         prefixes that are attached to these community-types.";
+         communities that are attached to BGP routes for these
+         community-types.";
     }
     leaf description {
       type string;

--- a/src/yang/ietf-bgp-common.yang
+++ b/src/yang/ietf-bgp-common.yang
@@ -926,7 +926,7 @@ submodule ietf-bgp-common {
 
   grouping dynamic-peers {
     description
-      "Grouping to contain dyamic BGP peers. Dynamic peers are
+      "Grouping to contain dynamic BGP peers. Dynamic peers are
        configured from a list of IP prefixes matching the IP source
        address of the dynamic peer.";
 

--- a/src/yang/ietf-bgp-common.yang
+++ b/src/yang/ietf-bgp-common.yang
@@ -362,7 +362,7 @@ submodule ietf-bgp-common {
       }
       description
         "Routes learned via BGP are subject to weighted route
-         dampening.";
+         damping.";
     }
     leaf-list send-community {
       if-feature "ibct:send-communities";

--- a/src/yang/ietf-bgp-community-types.yang
+++ b/src/yang/ietf-bgp-community-types.yang
@@ -63,7 +63,8 @@ module ietf-bgp-community-types {
     reference
       "RFC 1997: BGP Communities Attribute.
        RFC 4360: BGP Extended Communities Attribute.
-       RFC 5668: BGP Extended Community Attribute for Route Target Constraints.
+       RFC 5668: BGP Extended Community Attribute for Route Target
+                 Constraints.
        RFC 8092: BGP Large Communities Attribute.";
   }
 

--- a/src/yang/ietf-bgp-types.yang
+++ b/src/yang/ietf-bgp-types.yang
@@ -105,7 +105,7 @@ module ietf-bgp-types {
 
   feature damping {
     description
-      "Weighted route dampening is supported.";
+      "Weighted route damping is supported.";
     reference
       "RFC 2439: BGP Route Flap Damping.";
   }

--- a/src/yang/ietf-bgp.yang
+++ b/src/yang/ietf-bgp.yang
@@ -455,7 +455,7 @@ module ietf-bgp {
               type boolean;
               config false;
               description
-                "This flag indicates whether the local neighbor is
+                "This flag indicates whether the local session is
                  currently restarting. The flag is cleared after all
                  NLRI have been advertised to the peer, and the
                  End-of-RIB (EOR) marker has been cleared.";
@@ -465,14 +465,14 @@ module ietf-bgp {
               type enumeration {
                 enum helper-only {
                   description
-                    "The local router is operating in helper-only
+                    "The local system is operating in helper-only
                      mode, and hence will not retain forwarding state
                      during a local session restart, but will do so
                      during a restart of the remote peer";
                 }
                 enum bilateral {
                   description
-                    "The local router is operating in both helper
+                    "The local system is operating in both helper
                      mode, and hence retains forwarding state during
                      a remote restart, and also maintains forwarding
                      state during local session restart";

--- a/src/yang/ietf-bgp.yang
+++ b/src/yang/ietf-bgp.yang
@@ -677,7 +677,7 @@ module ietf-bgp {
                 "Clear statistics action command.
 
                  Execution of this command should result in all the
-                 counters to be cleared and set to 0.";
+                 statistics to be cleared and set to 0.";
 
               input {
                 leaf clear-at {

--- a/src/yang/ietf-bgp.yang
+++ b/src/yang/ietf-bgp.yang
@@ -297,7 +297,7 @@ module ietf-bgp {
 
       container neighbors {
         description
-          "Configuration for BGP neighbors.";
+          "Configuration and operational state for BGP neighbors.";
 
         list neighbor {
           key "neighbor-key";


### PR DESCRIPTION
Closes #496.

Fix warning from long line
Update description for container neighbors to note operational state
Address graceful restart local naming issues
Update text on 'clear bgp statistics' to be clear that it is statistic related, not data type.
Add reference for RFC 2439 to container route-flap-damping
Fix description for send-community
Add text covering dynamic-peering sessions

Note that this does not address a more flexible type for leaf identifier to permit uint32 as a union.